### PR TITLE
Align skill-creator parity with Claude workflow in OpenCode

### DIFF
--- a/plugin/lib/aggregate.ts
+++ b/plugin/lib/aggregate.ts
@@ -45,6 +45,34 @@ export interface BenchmarkOutput {
   notes: string[]
 }
 
+interface LoadResultsOutput {
+  results: Record<string, RunResult[]>
+  evalIds: Array<number | string>
+}
+
+function computeRunsPerConfiguration(results: Record<string, RunResult[]>): number {
+  const counts: number[] = []
+
+  for (const runs of Object.values(results)) {
+    const byEval = new Map<string, Set<number>>()
+
+    for (const run of runs) {
+      const evalKey = String(run.eval_id)
+      if (!byEval.has(evalKey)) {
+        byEval.set(evalKey, new Set<number>())
+      }
+      byEval.get(evalKey)!.add(run.run_number)
+    }
+
+    for (const set of byEval.values()) {
+      counts.push(set.size)
+    }
+  }
+
+  if (counts.length === 0) return 0
+  return Math.max(...counts)
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -86,7 +114,7 @@ function sortedDirs(dir: string, pattern?: RegExp): string[] {
 // Load run results
 // ---------------------------------------------------------------------------
 
-function loadRunResults(benchmarkDir: string): Record<string, RunResult[]> {
+function loadRunResults(benchmarkDir: string): LoadResultsOutput {
   // Support both layouts
   const runsDir = join(benchmarkDir, "runs")
   let searchDir: string
@@ -98,10 +126,11 @@ function loadRunResults(benchmarkDir: string): Record<string, RunResult[]> {
     console.error(
       `No eval directories found in ${benchmarkDir} or ${runsDir}`,
     )
-    return {}
+    return { results: {}, evalIds: [] }
   }
 
   const results: Record<string, RunResult[]> = {}
+  const evalIds = new Set<number | string>()
 
   for (const [evalIdx, evalDir] of sortedDirs(searchDir, /^eval-/).entries()) {
     const metadataPath = join(evalDir, "eval_metadata.json")
@@ -120,6 +149,7 @@ function loadRunResults(benchmarkDir: string): Record<string, RunResult[]> {
         /* ignore */
       }
     }
+    evalIds.add(evalId)
 
     // Discover config directories dynamically
     for (const configDir of sortedDirs(evalDir)) {
@@ -204,7 +234,10 @@ function loadRunResults(benchmarkDir: string): Record<string, RunResult[]> {
     }
   }
 
-  return results
+  return {
+    results,
+    evalIds: [...evalIds].sort(),
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -270,7 +303,8 @@ export function generateBenchmark(
   skillName = "",
   skillPath = "",
 ): BenchmarkOutput {
-  const results = loadRunResults(benchmarkDir)
+  const loaded = loadRunResults(benchmarkDir)
+  const results = loaded.results
   const runSummary = aggregateResults(results)
 
   // Build runs array
@@ -297,14 +331,7 @@ export function generateBenchmark(
     }
   }
 
-  // Determine eval IDs
-  const evalIds = [
-    ...new Set(
-      Object.values(results)
-        .flat()
-        .map((r) => r.eval_id),
-    ),
-  ].sort()
+  const runsPerConfiguration = computeRunsPerConfiguration(results)
 
   return {
     metadata: {
@@ -313,8 +340,8 @@ export function generateBenchmark(
       executor_model: "<model-name>",
       analyzer_model: "<model-name>",
       timestamp: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
-      evals_run: evalIds,
-      runs_per_configuration: 3,
+      evals_run: loaded.evalIds,
+      runs_per_configuration: runsPerConfiguration,
     },
     runs,
     run_summary: runSummary,

--- a/plugin/lib/aggregate.ts
+++ b/plugin/lib/aggregate.ts
@@ -50,6 +50,23 @@ interface LoadResultsOutput {
   evalIds: Array<number | string>
 }
 
+function compareEvalIds(a: number | string, b: number | string): number {
+  const parseNumeric = (value: number | string): number | null => {
+    if (typeof value === "number" && Number.isFinite(value)) return value
+    if (typeof value !== "string") return null
+    const trimmed = value.trim()
+    if (!/^-?\d+$/.test(trimmed)) return null
+    const num = Number(trimmed)
+    return Number.isFinite(num) ? num : null
+  }
+
+  const aNum = parseNumeric(a)
+  const bNum = parseNumeric(b)
+  if (aNum !== null && bNum !== null) return aNum - bNum
+
+  return String(a).localeCompare(String(b), undefined, { numeric: true })
+}
+
 function computeRunsPerConfiguration(results: Record<string, RunResult[]>): number {
   const counts: number[] = []
 
@@ -149,7 +166,7 @@ function loadRunResults(benchmarkDir: string): LoadResultsOutput {
         /* ignore */
       }
     }
-    evalIds.add(evalId)
+    let hasLoadedRuns = false
 
     // Discover config directories dynamically
     for (const configDir of sortedDirs(evalDir)) {
@@ -230,13 +247,18 @@ function loadRunResults(benchmarkDir: string): LoadResultsOutput {
         result.notes = notes
 
         results[config].push(result)
+        hasLoadedRuns = true
       }
+    }
+
+    if (hasLoadedRuns) {
+      evalIds.add(evalId)
     }
   }
 
   return {
     results,
-    evalIds: [...evalIds].sort(),
+    evalIds: [...evalIds].sort(compareEvalIds),
   }
 }
 

--- a/plugin/lib/aggregate.ts
+++ b/plugin/lib/aggregate.ts
@@ -70,7 +70,7 @@ function computeRunsPerConfiguration(results: Record<string, RunResult[]>): numb
   }
 
   if (counts.length === 0) return 0
-  return Math.max(...counts)
+  return Math.min(...counts)
 }
 
 // ---------------------------------------------------------------------------

--- a/plugin/lib/aggregate.ts
+++ b/plugin/lib/aggregate.ts
@@ -67,10 +67,18 @@ function compareEvalIds(a: number | string, b: number | string): number {
   return String(a).localeCompare(String(b), undefined, { numeric: true })
 }
 
-function computeRunsPerConfiguration(results: Record<string, RunResult[]>): number {
+function computeRunsPerConfiguration(
+  results: Record<string, RunResult[]>,
+  evalIds: Array<number | string>,
+): number {
   const counts: number[] = []
 
   for (const runs of Object.values(results)) {
+    if (runs.length === 0) {
+      counts.push(0)
+      continue
+    }
+
     const byEval = new Map<string, Set<number>>()
 
     for (const run of runs) {
@@ -81,8 +89,14 @@ function computeRunsPerConfiguration(results: Record<string, RunResult[]>): numb
       byEval.get(evalKey)!.add(run.run_number)
     }
 
-    for (const set of byEval.values()) {
-      counts.push(set.size)
+    if (evalIds.length === 0) {
+      counts.push(0)
+      continue
+    }
+
+    for (const evalId of evalIds) {
+      const set = byEval.get(String(evalId))
+      counts.push(set ? set.size : 0)
     }
   }
 
@@ -364,7 +378,7 @@ export function generateBenchmark(
     }
   }
 
-  const runsPerConfiguration = computeRunsPerConfiguration(results)
+  const runsPerConfiguration = computeRunsPerConfiguration(results, loaded.evalIds)
 
   return {
     metadata: {

--- a/plugin/lib/aggregate.ts
+++ b/plugin/lib/aggregate.ts
@@ -160,10 +160,12 @@ function loadRunResults(benchmarkDir: string): LoadResultsOutput {
         /* ignore */
       }
     } else {
-      try {
-        evalId = parseInt(basename(evalDir).split("-")[1], 10)
-      } catch {
-        /* ignore */
+      const parsedEvalId = Number.parseInt(
+        basename(evalDir).split("-")[1] ?? "",
+        10,
+      )
+      if (Number.isFinite(parsedEvalId)) {
+        evalId = parsedEvalId
       }
     }
     let hasLoadedRuns = false
@@ -177,7 +179,16 @@ function loadRunResults(benchmarkDir: string): LoadResultsOutput {
       if (!results[config]) results[config] = []
 
       for (const runDir of sortedDirs(configDir, /^run-/)) {
-        const runNumber = parseInt(basename(runDir).split("-")[1], 10)
+        const parsedRunNumber = Number.parseInt(
+          basename(runDir).split("-")[1] ?? "",
+          10,
+        )
+        if (!Number.isFinite(parsedRunNumber)) {
+          console.error(`Warning: Invalid run directory name: ${runDir}`)
+          continue
+        }
+
+        const runNumber = parsedRunNumber
         const gradingFile = join(runDir, "grading.json")
 
         if (!existsSync(gradingFile)) {

--- a/plugin/lib/improve-description.ts
+++ b/plugin/lib/improve-description.ts
@@ -48,7 +48,33 @@ async function callOpenCode(
     const textParts: string[] = []
     const decoder = new TextDecoder()
     const reader = proc.stdout.getReader()
+    const stderrReader = proc.stderr.getReader()
+    const stderrDecoder = new TextDecoder()
+    const maxStderrChars = 64 * 1024
+    let stderrTail = ""
     const timeoutMs = timeout * 1000
+
+    const stderrDrained = (async () => {
+      try {
+        while (true) {
+          const result = await stderrReader.read()
+          if (result.done) break
+          if (!result.value) continue
+
+          stderrTail += stderrDecoder.decode(result.value, { stream: true })
+          if (stderrTail.length > maxStderrChars) {
+            stderrTail = stderrTail.slice(-maxStderrChars)
+          }
+        }
+
+        stderrTail += stderrDecoder.decode()
+        if (stderrTail.length > maxStderrChars) {
+          stderrTail = stderrTail.slice(-maxStderrChars)
+        }
+      } finally {
+        stderrReader.releaseLock()
+      }
+    })()
 
     const consumeLine = (line: string) => {
       const trimmed = line.trim()
@@ -103,6 +129,7 @@ async function callOpenCode(
 
       flushLines(true)
       await proc.exited
+      await stderrDrained
     } finally {
       clearTimeout(timeoutId)
       reader.releaseLock()
@@ -111,23 +138,12 @@ async function callOpenCode(
         proc.kill()
         await proc.exited
       }
-    }
 
-    // Check stderr for errors
-    const stderrReader = proc.stderr.getReader()
-    let stderr = ""
-    try {
-      while (true) {
-        const r = await stderrReader.read()
-        if (r.done) break
-        if (r.value) stderr += decoder.decode(r.value, { stream: true })
-      }
-    } finally {
-      stderrReader.releaseLock()
+      await stderrDrained.catch(() => undefined)
     }
 
     if (proc.exitCode !== 0 && proc.exitCode !== null) {
-      throw new Error(`opencode run exited ${proc.exitCode}\nstderr: ${stderr}`)
+      throw new Error(`opencode run exited ${proc.exitCode}\nstderr: ${stderrTail}`)
     }
 
     if (textParts.length > 0) {

--- a/plugin/lib/improve-description.ts
+++ b/plugin/lib/improve-description.ts
@@ -127,6 +127,12 @@ async function callOpenCode(
         }
       }
 
+      const finalChunk = decoder.decode()
+      if (finalChunk) {
+        stdout += finalChunk
+        lineBuffer += finalChunk
+      }
+
       flushLines(true)
       await proc.exited
       await stderrDrained

--- a/plugin/lib/improve-description.ts
+++ b/plugin/lib/improve-description.ts
@@ -60,7 +60,7 @@ async function callOpenCode(
         const part = event.part as Record<string, unknown> | undefined
         if (!part || typeof part !== "object") return
         const text = part.text
-        if (typeof text === "string" && text.trim()) {
+        if (typeof text === "string") {
           textParts.push(text)
         }
       } catch {
@@ -131,7 +131,7 @@ async function callOpenCode(
     }
 
     if (textParts.length > 0) {
-      return textParts.join("\n")
+      return textParts.join("")
     }
 
     return stdout

--- a/plugin/lib/improve-description.ts
+++ b/plugin/lib/improve-description.ts
@@ -32,7 +32,7 @@ async function callOpenCode(
   writeFileSync(tmpPath, prompt)
 
   try {
-    const cmd = ["opencode", "run"]
+    const cmd = ["opencode", "run", "--format", "json"]
     if (model) cmd.push("--model", model)
     cmd.push("--file", tmpPath, "Process the attached file and follow its instructions.")
 
@@ -42,30 +42,75 @@ async function callOpenCode(
       env: { ...process.env },
     })
 
-    // Collect stdout with timeout
+    // Collect stdout with timeout. Prefer structured text events from JSON mode.
     let stdout = ""
+    let lineBuffer = ""
+    const textParts: string[] = []
     const decoder = new TextDecoder()
     const reader = proc.stdout.getReader()
-    const deadline = Date.now() + timeout * 1000
+    const timeoutMs = timeout * 1000
 
-    try {
-      while (Date.now() < deadline) {
-        const remaining = deadline - Date.now()
-        const result = await Promise.race([
-          reader.read(),
-          new Promise<{ done: true; value: undefined }>((resolve) =>
-            setTimeout(() => resolve({ done: true, value: undefined }), remaining),
-          ),
-        ])
-        if (result.done) break
-        if (result.value) stdout += decoder.decode(result.value, { stream: true })
+    const consumeLine = (line: string) => {
+      const trimmed = line.trim()
+      if (!trimmed) return
+
+      try {
+        const event = JSON.parse(trimmed) as Record<string, unknown>
+        if (event.type !== "text") return
+        const part = event.part as Record<string, unknown> | undefined
+        if (!part || typeof part !== "object") return
+        const text = part.text
+        if (typeof text === "string" && text.trim()) {
+          textParts.push(text)
+        }
+      } catch {
+        // Ignore non-JSON lines.
       }
-    } finally {
-      reader.releaseLock()
+    }
+
+    const flushLines = (final = false) => {
+      let idx = lineBuffer.indexOf("\n")
+      while (idx !== -1) {
+        const line = lineBuffer.slice(0, idx)
+        lineBuffer = lineBuffer.slice(idx + 1)
+        consumeLine(line)
+        idx = lineBuffer.indexOf("\n")
+      }
+
+      if (final && lineBuffer.trim()) {
+        consumeLine(lineBuffer)
+        lineBuffer = ""
+      }
+    }
+
+    const timeoutId = setTimeout(() => {
       if (proc.exitCode === null) {
         proc.kill()
       }
+    }, timeoutMs)
+
+    try {
+      while (true) {
+        const result = await reader.read()
+        if (result.done) break
+        if (result.value) {
+          const chunk = decoder.decode(result.value, { stream: true })
+          stdout += chunk
+          lineBuffer += chunk
+          flushLines()
+        }
+      }
+
+      flushLines(true)
       await proc.exited
+    } finally {
+      clearTimeout(timeoutId)
+      reader.releaseLock()
+
+      if (proc.exitCode === null) {
+        proc.kill()
+        await proc.exited
+      }
     }
 
     // Check stderr for errors
@@ -83,6 +128,10 @@ async function callOpenCode(
 
     if (proc.exitCode !== 0 && proc.exitCode !== null) {
       throw new Error(`opencode run exited ${proc.exitCode}\nstderr: ${stderr}`)
+    }
+
+    if (textParts.length > 0) {
+      return textParts.join("\n")
     }
 
     return stdout

--- a/plugin/lib/run-eval.ts
+++ b/plugin/lib/run-eval.ts
@@ -117,7 +117,33 @@ async function runSingleQuery(
     let triggered = false
     const decoder = new TextDecoder()
     const reader = proc.stdout.getReader()
+    const stderrReader = proc.stderr.getReader()
+    const stderrDecoder = new TextDecoder()
+    const maxStderrChars = 64 * 1024
+    let stderrTail = ""
     const timeoutMs = timeout * 1000
+
+    const stderrDrained = (async () => {
+      try {
+        while (true) {
+          const result = await stderrReader.read()
+          if (result.done) break
+          if (!result.value) continue
+
+          stderrTail += stderrDecoder.decode(result.value, { stream: true })
+          if (stderrTail.length > maxStderrChars) {
+            stderrTail = stderrTail.slice(-maxStderrChars)
+          }
+        }
+
+        stderrTail += stderrDecoder.decode()
+        if (stderrTail.length > maxStderrChars) {
+          stderrTail = stderrTail.slice(-maxStderrChars)
+        }
+      } finally {
+        stderrReader.releaseLock()
+      }
+    })()
 
     const consumeLine = (line: string) => {
       const trimmed = line.trim()
@@ -175,10 +201,10 @@ async function runSingleQuery(
 
       flushBuffer(true)
       await proc.exited
+      await stderrDrained
 
       if ((proc.exitCode ?? 0) !== 0) {
-        const stderrText = await new Response(proc.stderr).text()
-        const cleanedStderr = stderrText.trim()
+        const cleanedStderr = stderrTail.trim()
         throw new Error(
           cleanedStderr
             ? `opencode run exited ${proc.exitCode}: ${cleanedStderr}`
@@ -193,6 +219,8 @@ async function runSingleQuery(
         proc.kill()
         await proc.exited
       }
+
+      await stderrDrained.catch(() => undefined)
     }
 
     return triggered

--- a/plugin/lib/run-eval.ts
+++ b/plugin/lib/run-eval.ts
@@ -14,6 +14,8 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs"
 import { dirname, join, parse } from "path"
 import { randomBytes } from "crypto"
 
+const SKILL_NAME_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -77,6 +79,12 @@ async function runSingleQuery(
   projectRoot: string,
   model?: string,
 ): Promise<boolean> {
+  if (!SKILL_NAME_RE.test(skillName)) {
+    throw new Error(
+      `Invalid skill name "${skillName}". Expected kebab-case (lowercase letters, numbers, and hyphens only).`,
+    )
+  }
+
   const uniqueId = randomBytes(4).toString("hex")
   const cleanName = `${skillName}-skill-${uniqueId}`
   const skillsDir = join(projectRoot, ".opencode", "skills", cleanName)

--- a/plugin/lib/run-eval.ts
+++ b/plugin/lib/run-eval.ts
@@ -108,7 +108,7 @@ async function runSingleQuery(
     const proc = Bun.spawn(cmd, {
       cwd: projectRoot,
       stdout: "pipe",
-      stderr: "ignore",
+      stderr: "pipe",
       env: { ...process.env },
     })
 
@@ -175,6 +175,16 @@ async function runSingleQuery(
 
       flushBuffer(true)
       await proc.exited
+
+      if ((proc.exitCode ?? 0) !== 0) {
+        const stderrText = await new Response(proc.stderr).text()
+        const cleanedStderr = stderrText.trim()
+        throw new Error(
+          cleanedStderr
+            ? `opencode run exited ${proc.exitCode}: ${cleanedStderr}`
+            : `opencode run exited ${proc.exitCode}`,
+        )
+      }
     } finally {
       clearTimeout(timeoutId)
       reader.releaseLock()

--- a/plugin/lib/run-eval.ts
+++ b/plugin/lib/run-eval.ts
@@ -199,6 +199,11 @@ async function runSingleQuery(
         }
       }
 
+      const finalChunk = decoder.decode()
+      if (finalChunk) {
+        buffer += finalChunk
+      }
+
       flushBuffer(true)
       await proc.exited
       await stderrDrained

--- a/plugin/lib/run-eval.ts
+++ b/plugin/lib/run-eval.ts
@@ -31,6 +31,8 @@ export interface EvalResultItem {
   trigger_rate: number
   triggers: number
   runs: number
+  successful_runs: number
+  errors: number
   pass: boolean
 }
 
@@ -42,6 +44,8 @@ export interface EvalOutput {
     total: number
     passed: number
     failed: number
+    run_errors: number
+    queries_with_errors: number
   }
 }
 
@@ -290,7 +294,12 @@ export async function runEval(opts: RunEvalOptions): Promise<EvalOutput> {
   }
 
   // Concurrency-limited execution
-  const jobResults: { query: string; triggered: boolean; item: EvalItem }[] = []
+  const jobResults: {
+    query: string
+    triggered: boolean
+    item: EvalItem
+    errored: boolean
+  }[] = []
   let idx = 0
 
   async function worker() {
@@ -306,10 +315,20 @@ export async function runEval(opts: RunEvalOptions): Promise<EvalOutput> {
           projectRoot,
           model,
         )
-        jobResults.push({ query: job.item.query, triggered, item: job.item })
+        jobResults.push({
+          query: job.item.query,
+          triggered,
+          item: job.item,
+          errored: false,
+        })
       } catch (e) {
         console.error(`Warning: query failed: ${e}`)
-        jobResults.push({ query: job.item.query, triggered: false, item: job.item })
+        jobResults.push({
+          query: job.item.query,
+          triggered: false,
+          item: job.item,
+          errored: true,
+        })
       }
     }
   }
@@ -319,21 +338,27 @@ export async function runEval(opts: RunEvalOptions): Promise<EvalOutput> {
 
   // Aggregate per-query
   const queryTriggers: Map<string, boolean[]> = new Map()
+  const queryErrors: Map<string, number> = new Map()
   const queryItems: Map<string, EvalItem> = new Map()
   for (const jr of jobResults) {
     if (!queryTriggers.has(jr.query)) queryTriggers.set(jr.query, [])
     queryTriggers.get(jr.query)!.push(jr.triggered)
+    queryErrors.set(jr.query, (queryErrors.get(jr.query) ?? 0) + (jr.errored ? 1 : 0))
     queryItems.set(jr.query, jr.item)
   }
 
   const results: EvalResultItem[] = []
   for (const [query, triggers] of queryTriggers) {
     const item = queryItems.get(query)!
-    const triggerRate = triggers.filter(Boolean).length / triggers.length
+    const errors = queryErrors.get(query) ?? 0
+    const successfulRuns = triggers.length - errors
+    const triggerRate =
+      successfulRuns > 0 ? triggers.filter(Boolean).length / successfulRuns : 0
     const shouldTrigger = item.should_trigger
-    const didPass = shouldTrigger
+    const thresholdPass = shouldTrigger
       ? triggerRate >= triggerThreshold
       : triggerRate < triggerThreshold
+    const didPass = errors === 0 && thresholdPass
 
     results.push({
       query,
@@ -341,11 +366,15 @@ export async function runEval(opts: RunEvalOptions): Promise<EvalOutput> {
       trigger_rate: triggerRate,
       triggers: triggers.filter(Boolean).length,
       runs: triggers.length,
+      successful_runs: successfulRuns,
+      errors,
       pass: didPass,
     })
   }
 
   const passed = results.filter((r) => r.pass).length
+  const runErrors = results.reduce((acc, r) => acc + r.errors, 0)
+  const queriesWithErrors = results.filter((r) => r.errors > 0).length
 
   return {
     skill_name: skillName,
@@ -355,6 +384,8 @@ export async function runEval(opts: RunEvalOptions): Promise<EvalOutput> {
       total: results.length,
       passed,
       failed: results.length - passed,
+      run_errors: runErrors,
+      queries_with_errors: queriesWithErrors,
     },
   }
 }

--- a/plugin/lib/run-eval.ts
+++ b/plugin/lib/run-eval.ts
@@ -11,9 +11,8 @@
  */
 
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs"
-import { join } from "path"
+import { dirname, join, parse } from "path"
 import { randomBytes } from "crypto"
-import { parseSkillMd } from "./utils"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -54,12 +53,12 @@ export interface EvalOutput {
  */
 export function findProjectRoot(cwd?: string): string {
   let current = cwd ?? process.cwd()
-  const { root } = require("path").parse(current)
+  const { root } = parse(current)
 
   while (true) {
     if (existsSync(join(current, ".opencode"))) return current
     if (existsSync(join(current, ".claude"))) return current
-    const parent = require("path").dirname(current)
+    const parent = dirname(current)
     if (parent === current || parent === root) break
     current = parent
   }
@@ -102,7 +101,7 @@ async function runSingleQuery(
     ].join("\n")
     writeFileSync(skillFile, skillContent)
 
-    const cmd = ["opencode", "run"]
+    const cmd = ["opencode", "run", "--format", "json"]
     if (model) cmd.push("--model", model)
     cmd.push(query)
 
@@ -113,33 +112,80 @@ async function runSingleQuery(
       env: { ...process.env },
     })
 
-    // Collect output with timeout
+    // Collect output with timeout and detect skill invocation from JSON events.
     let buffer = ""
+    let triggered = false
     const decoder = new TextDecoder()
     const reader = proc.stdout.getReader()
-    const deadline = Date.now() + timeout * 1000
+    const timeoutMs = timeout * 1000
+
+    const consumeLine = (line: string) => {
+      const trimmed = line.trim()
+      if (!trimmed) return
+
+      try {
+        const event = JSON.parse(trimmed) as Record<string, unknown>
+        if (event.type !== "tool_use") return
+
+        const part = event.part as Record<string, unknown> | undefined
+        if (!part || typeof part !== "object") return
+
+        const toolName = typeof part.tool === "string" ? part.tool : ""
+        if (toolName !== "skill" && toolName !== "read") return
+
+        const serialized = JSON.stringify(part)
+        if (serialized.includes(cleanName)) {
+          triggered = true
+        }
+      } catch {
+        // Ignore non-JSON lines and malformed events.
+      }
+    }
+
+    const flushBuffer = (final = false) => {
+      let newlineIndex = buffer.indexOf("\n")
+      while (newlineIndex !== -1) {
+        const line = buffer.slice(0, newlineIndex)
+        buffer = buffer.slice(newlineIndex + 1)
+        consumeLine(line)
+        newlineIndex = buffer.indexOf("\n")
+      }
+
+      if (final && buffer.trim()) {
+        consumeLine(buffer)
+        buffer = ""
+      }
+    }
+
+    const timeoutId = setTimeout(() => {
+      if (proc.exitCode === null) {
+        proc.kill()
+      }
+    }, timeoutMs)
 
     try {
-      while (Date.now() < deadline) {
-        const remaining = deadline - Date.now()
-        const result = await Promise.race([
-          reader.read(),
-          new Promise<{ done: true; value: undefined }>((resolve) =>
-            setTimeout(() => resolve({ done: true, value: undefined }), remaining),
-          ),
-        ])
+      while (true) {
+        const result = await reader.read()
         if (result.done) break
         if (result.value) {
           buffer += decoder.decode(result.value, { stream: true })
+          flushBuffer()
         }
       }
-    } finally {
-      reader.releaseLock()
-      proc.kill()
+
+      flushBuffer(true)
       await proc.exited
+    } finally {
+      clearTimeout(timeoutId)
+      reader.releaseLock()
+
+      if (proc.exitCode === null) {
+        proc.kill()
+        await proc.exited
+      }
     }
 
-    return buffer.includes(cleanName)
+    return triggered
   } finally {
     // Clean up the temporary skill directory
     if (existsSync(skillsDir)) {
@@ -178,7 +224,7 @@ export async function runEval(opts: RunEvalOptions): Promise<EvalOutput> {
     numWorkers,
     timeout,
     projectRoot,
-    runsPerQuery = 1,
+    runsPerQuery = 3,
     triggerThreshold = 0.5,
     model,
   } = opts

--- a/plugin/lib/run-loop.ts
+++ b/plugin/lib/run-loop.ts
@@ -97,6 +97,17 @@ export interface RunLoopOptions {
 
 export interface LoopHistoryEntry extends HistoryEntry {
   iteration: number
+  description: string
+  train_passed: number
+  train_failed: number
+  train_total: number
+  test_passed: number | null
+  test_failed: number | null
+  test_total: number | null
+  passed: number
+  failed: number
+  total: number
+  results: EvalResultItem[]
   train_results?: EvalResultItem[]
   test_results?: EvalResultItem[] | null
 }

--- a/plugin/skill-creator.ts
+++ b/plugin/skill-creator.ts
@@ -15,6 +15,7 @@
 
 import { type Plugin, tool } from "@opencode-ai/plugin"
 import { join, dirname } from "path"
+import { homedir } from "os"
 import {
   existsSync,
   mkdirSync,
@@ -83,7 +84,7 @@ function copyDirRecursive(src: string, dest: string): void {
 function ensureSkillInstalled(): void {
   // Determine the global skills directory
   const configDir =
-    process.env.XDG_CONFIG_HOME || join(process.env.HOME || "~", ".config")
+    process.env.XDG_CONFIG_HOME || join(homedir(), ".config")
   const skillsDir = join(configDir, "opencode", "skills", "skill-creator")
   const marker = join(skillsDir, "SKILL.md")
   const versionFile = join(skillsDir, INSTALL_VERSION_FILE)

--- a/plugin/skill-creator.ts
+++ b/plugin/skill-creator.ts
@@ -246,6 +246,11 @@ export const SkillCreatorPlugin: Plugin = async (ctx) => {
             readFileSync(args.evalSetPath, "utf-8"),
           )
 
+          const validation = validateSkill(args.skillPath)
+          if (!validation.valid) {
+            throw new Error(`Invalid skill at ${args.skillPath}: ${validation.message}`)
+          }
+
           const meta = parseSkillMd(args.skillPath)
           const projectRoot = findProjectRoot()
 

--- a/plugin/skill-creator.ts
+++ b/plugin/skill-creator.ts
@@ -19,8 +19,10 @@ import {
   existsSync,
   mkdirSync,
   copyFileSync,
+  rmSync,
   readdirSync,
   readFileSync,
+  renameSync,
   statSync,
   writeFileSync,
 } from "fs"
@@ -85,6 +87,8 @@ function ensureSkillInstalled(): void {
   const skillsDir = join(configDir, "opencode", "skills", "skill-creator")
   const marker = join(skillsDir, "SKILL.md")
   const versionFile = join(skillsDir, INSTALL_VERSION_FILE)
+  const userSkillFile = join(skillsDir, "SKILL.md")
+  const userSkillBackup = join(skillsDir, "SKILL.md.user-backup")
 
   // Skip if bundled skill files are missing (e.g., local dev without skill/)
   if (!existsSync(BUNDLED_SKILL_DIR)) return
@@ -103,7 +107,31 @@ function ensureSkillInstalled(): void {
   if (!shouldInstall) return
 
   try {
-    copyDirRecursive(BUNDLED_SKILL_DIR, skillsDir)
+    const tmpInstallDir = `${skillsDir}.tmp-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+    copyDirRecursive(BUNDLED_SKILL_DIR, tmpInstallDir)
+
+    // Preserve user-customized SKILL.md when updating.
+    if (existsSync(userSkillFile)) {
+      try {
+        copyFileSync(userSkillFile, userSkillBackup)
+      } catch {
+        // Ignore backup failures; continue install.
+      }
+
+      try {
+        copyFileSync(userSkillFile, join(tmpInstallDir, "SKILL.md"))
+      } catch {
+        // If copy fails, continue with bundled SKILL.md.
+      }
+    }
+
+    if (!existsSync(skillsDir)) {
+      renameSync(tmpInstallDir, skillsDir)
+    } else {
+      copyDirRecursive(tmpInstallDir, skillsDir)
+      rmSync(tmpInstallDir, { recursive: true, force: true })
+    }
+
     writeFileSync(versionFile, `${PACKAGE_VERSION}\n`)
   } catch {
     // Silently fail — the user can always install manually

--- a/plugin/skill-creator.ts
+++ b/plugin/skill-creator.ts
@@ -21,7 +21,6 @@ import {
   copyFileSync,
   readdirSync,
   readFileSync,
-  rmSync,
   statSync,
   writeFileSync,
 } from "fs"
@@ -104,9 +103,6 @@ function ensureSkillInstalled(): void {
   if (!shouldInstall) return
 
   try {
-    if (existsSync(skillsDir)) {
-      rmSync(skillsDir, { recursive: true, force: true })
-    }
     copyDirRecursive(BUNDLED_SKILL_DIR, skillsDir)
     writeFileSync(versionFile, `${PACKAGE_VERSION}\n`)
   } catch {

--- a/plugin/skill-creator.ts
+++ b/plugin/skill-creator.ts
@@ -106,8 +106,9 @@ function ensureSkillInstalled(): void {
   const shouldInstall = !existsSync(marker) || installedVersion !== PACKAGE_VERSION
   if (!shouldInstall) return
 
+  const tmpInstallDir = `${skillsDir}.tmp-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+
   try {
-    const tmpInstallDir = `${skillsDir}.tmp-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
     copyDirRecursive(BUNDLED_SKILL_DIR, tmpInstallDir)
 
     // Preserve user-customized SKILL.md when updating.
@@ -129,12 +130,15 @@ function ensureSkillInstalled(): void {
       renameSync(tmpInstallDir, skillsDir)
     } else {
       copyDirRecursive(tmpInstallDir, skillsDir)
-      rmSync(tmpInstallDir, { recursive: true, force: true })
     }
 
     writeFileSync(versionFile, `${PACKAGE_VERSION}\n`)
   } catch {
     // Silently fail — the user can always install manually
+  } finally {
+    if (existsSync(tmpInstallDir)) {
+      rmSync(tmpInstallDir, { recursive: true, force: true })
+    }
   }
 }
 

--- a/plugin/skill-creator.ts
+++ b/plugin/skill-creator.ts
@@ -20,7 +20,10 @@ import {
   mkdirSync,
   copyFileSync,
   readdirSync,
+  readFileSync,
+  rmSync,
   statSync,
+  writeFileSync,
 } from "fs"
 
 import { validateSkill } from "./lib/validate"
@@ -45,6 +48,19 @@ const TEMPLATES_DIR = join(dirname(import.meta.path), "templates")
 // ---------------------------------------------------------------------------
 
 const BUNDLED_SKILL_DIR = join(dirname(import.meta.path), "skill")
+const PACKAGE_JSON_PATH = join(dirname(import.meta.path), "package.json")
+const INSTALL_VERSION_FILE = ".opencode-skill-creator-version"
+
+const PACKAGE_VERSION = (() => {
+  try {
+    const pkg = JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf-8")) as {
+      version?: string
+    }
+    return pkg.version ?? "0.0.0"
+  } catch {
+    return "0.0.0"
+  }
+})()
 
 // ---------------------------------------------------------------------------
 // Auto-install: copy bundled skill files to the global skills directory
@@ -69,15 +85,30 @@ function ensureSkillInstalled(): void {
     process.env.XDG_CONFIG_HOME || join(process.env.HOME || "~", ".config")
   const skillsDir = join(configDir, "opencode", "skills", "skill-creator")
   const marker = join(skillsDir, "SKILL.md")
-
-  // Skip if skill is already installed
-  if (existsSync(marker)) return
+  const versionFile = join(skillsDir, INSTALL_VERSION_FILE)
 
   // Skip if bundled skill files are missing (e.g., local dev without skill/)
   if (!existsSync(BUNDLED_SKILL_DIR)) return
 
+  // Install/update when missing, or when package version changed.
+  let installedVersion = ""
+  if (existsSync(versionFile)) {
+    try {
+      installedVersion = readFileSync(versionFile, "utf-8").trim()
+    } catch {
+      installedVersion = ""
+    }
+  }
+
+  const shouldInstall = !existsSync(marker) || installedVersion !== PACKAGE_VERSION
+  if (!shouldInstall) return
+
   try {
+    if (existsSync(skillsDir)) {
+      rmSync(skillsDir, { recursive: true, force: true })
+    }
     copyDirRecursive(BUNDLED_SKILL_DIR, skillsDir)
+    writeFileSync(versionFile, `${PACKAGE_VERSION}\n`)
   } catch {
     // Silently fail — the user can always install manually
   }
@@ -130,7 +161,12 @@ export const SkillCreatorPlugin: Plugin = async (ctx) => {
         async execute(args) {
           const meta = parseSkillMd(args.skillPath)
           return JSON.stringify(
-            { name: meta.name, description: meta.description, contentLength: meta.fullContent.length },
+            {
+              name: meta.name,
+              description: meta.description,
+              content: meta.fullContent,
+              contentLength: meta.fullContent.length,
+            },
             null,
             2,
           )
@@ -157,15 +193,15 @@ export const SkillCreatorPlugin: Plugin = async (ctx) => {
           numWorkers: tool.schema
             .number()
             .optional()
-            .describe("Parallel workers (default: 4)"),
+            .describe("Parallel workers (default: 10)"),
           timeout: tool.schema
             .number()
             .optional()
-            .describe("Timeout per query in seconds (default: 60)"),
+            .describe("Timeout per query in seconds (default: 30)"),
           runsPerQuery: tool.schema
             .number()
             .optional()
-            .describe("Number of runs per query for reliability (default: 1)"),
+            .describe("Number of runs per query for reliability (default: 3)"),
           triggerThreshold: tool.schema
             .number()
             .optional()
@@ -188,10 +224,10 @@ export const SkillCreatorPlugin: Plugin = async (ctx) => {
             evalSet,
             skillName: meta.name,
             description: args.descriptionOverride ?? meta.description,
-            numWorkers: args.numWorkers ?? 4,
-            timeout: args.timeout ?? 60,
+            numWorkers: args.numWorkers ?? 10,
+            timeout: args.timeout ?? 30,
             projectRoot,
-            runsPerQuery: args.runsPerQuery ?? 1,
+            runsPerQuery: args.runsPerQuery ?? 3,
             triggerThreshold: args.triggerThreshold ?? 0.5,
             model: args.model,
           })
@@ -277,11 +313,11 @@ export const SkillCreatorPlugin: Plugin = async (ctx) => {
           numWorkers: tool.schema
             .number()
             .optional()
-            .describe("Parallel workers (default: 4)"),
+            .describe("Parallel workers (default: 10)"),
           timeout: tool.schema
             .number()
             .optional()
-            .describe("Timeout per query in seconds (default: 60)"),
+            .describe("Timeout per query in seconds (default: 30)"),
           runsPerQuery: tool.schema
             .number()
             .optional()
@@ -317,8 +353,8 @@ export const SkillCreatorPlugin: Plugin = async (ctx) => {
             evalSet,
             skillPath: args.skillPath,
             descriptionOverride: args.descriptionOverride ?? null,
-            numWorkers: args.numWorkers ?? 4,
-            timeout: args.timeout ?? 60,
+            numWorkers: args.numWorkers ?? 10,
+            timeout: args.timeout ?? 30,
             maxIterations: args.maxIterations ?? 5,
             runsPerQuery: args.runsPerQuery ?? 3,
             triggerThreshold: args.triggerThreshold ?? 0.5,

--- a/plugin/skill/SKILL.md
+++ b/plugin/skill/SKILL.md
@@ -23,7 +23,9 @@ Your job when using this skill is to figure out where the user is in this proces
 
 On the other hand, maybe they already have a draft of the skill. In this case you can go straight to the eval/iterate part of the loop.
 
-Of course, you should always be flexible and if the user is like "I don't need to run a bunch of evaluations, just vibe with me", you can do that instead.
+For new skill creation, the intake interview is mandatory. Ask at least 3-5 targeted questions before drafting anything (ask more if the workflow is complex). Treat this as shadowing a teammate: the user is the domain expert and existing employee, and the agent is the new hire that must learn and mirror the real workflow.
+
+You can still be flexible about eval depth and iteration speed after intake. If the user asks to skip intake, warn once that skill quality and workflow match will be worse, get explicit confirmation, and then proceed with best effort.
 
 Then after the skill is done (but again, the order is flexible), you can also run the skill description optimizer (`skill_optimize_loop` tool), which we have a whole separate tool for, to optimize the triggering of the skill.
 
@@ -44,18 +46,27 @@ It's OK to briefly explain terms if you're in doubt, and feel free to clarify te
 
 ## Creating a skill
 
-### Capture Intent
+### Capture Intent (Required Gate for New Skills)
 
-Start by understanding the user's intent. The current conversation might already contain a workflow the user wants to capture (e.g., they say "turn this into a skill"). If so, extract answers from the conversation history first — the tools used, the sequence of steps, corrections the user made, input/output formats observed. The user may need to fill the gaps, and should confirm before proceeding to the next step.
+For new skills, this step is mandatory and cannot be skipped. Do not draft SKILL.md, evals, or other files until this interview is complete and the user confirms your summary.
 
-1. What should this skill enable OpenCode to do?
-2. When should this skill trigger? (what user phrases/contexts)
-3. What's the expected output format?
-4. Should we set up test cases to verify the skill works? Skills with objectively verifiable outputs (file transforms, data extraction, code generation, fixed workflow steps) benefit from test cases. Skills with subjective outputs (writing style, art) often don't need them. Suggest the appropriate default based on the skill type, but let the user decide.
+Start by understanding the user's intent. The current conversation might already contain part of the workflow the user wants to capture (e.g., they say "turn this into a skill"). Extract that first: tools used, sequence of steps, corrections, inputs/outputs, and success criteria. Then fill the gaps with questions.
+
+Ask at least 3-5 targeted questions (more when needed). Cover these minimum areas:
+
+1. What should this skill enable OpenCode to do end-to-end?
+2. When should this skill trigger? (phrases, contexts, near-misses)
+3. What output format and quality bar are expected?
+4. What workflow steps must be preserved exactly vs. where can the agent improvise?
+5. Should we set up test cases to verify behavior? Skills with objectively verifiable outputs (file transforms, data extraction, code generation, fixed workflow steps) benefit from test cases. Skills with subjective outputs (writing style, art) often don't need them. Suggest the appropriate default based on skill type, then let the user decide.
+
+Before moving on, summarize your understanding in plain language and ask the user to confirm or correct it.
+
+If the user explicitly asks to skip intake, warn that final quality and workflow fit will likely be worse. Proceed only after explicit confirmation.
 
 ### Interview and Research
 
-Proactively ask questions about edge cases, input/output formats, example files, success criteria, and dependencies. Wait to write test prompts until you've got this part ironed out.
+Proactively ask questions about edge cases, input/output formats, example files, success criteria, and dependencies. Use a buddy/shadowing stance: mirror the user's real workflow, terminology, handoffs, and decision points. Wait to write test prompts until you've got this part ironed out.
 
 Check available MCPs — if useful for research (searching docs, finding similar skills, looking up best practices), research in parallel via the Task tool (using `general` or `explore` subagent types) if available, otherwise inline. Come prepared with context to reduce burden on the user.
 

--- a/skill-creator/SKILL.md
+++ b/skill-creator/SKILL.md
@@ -23,7 +23,9 @@ Your job when using this skill is to figure out where the user is in this proces
 
 On the other hand, maybe they already have a draft of the skill. In this case you can go straight to the eval/iterate part of the loop.
 
-Of course, you should always be flexible and if the user is like "I don't need to run a bunch of evaluations, just vibe with me", you can do that instead.
+For new skill creation, the intake interview is mandatory. Ask at least 3-5 targeted questions before drafting anything (ask more if the workflow is complex). Treat this as shadowing a teammate: the user is the domain expert and existing employee, and the agent is the new hire that must learn and mirror the real workflow.
+
+You can still be flexible about eval depth and iteration speed after intake. If the user asks to skip intake, warn once that skill quality and workflow match will be worse, get explicit confirmation, and then proceed with best effort.
 
 Then after the skill is done (but again, the order is flexible), you can also run the skill description optimizer (`skill_optimize_loop` tool), which we have a whole separate tool for, to optimize the triggering of the skill.
 
@@ -44,18 +46,27 @@ It's OK to briefly explain terms if you're in doubt, and feel free to clarify te
 
 ## Creating a skill
 
-### Capture Intent
+### Capture Intent (Required Gate for New Skills)
 
-Start by understanding the user's intent. The current conversation might already contain a workflow the user wants to capture (e.g., they say "turn this into a skill"). If so, extract answers from the conversation history first — the tools used, the sequence of steps, corrections the user made, input/output formats observed. The user may need to fill the gaps, and should confirm before proceeding to the next step.
+For new skills, this step is mandatory and cannot be skipped. Do not draft SKILL.md, evals, or other files until this interview is complete and the user confirms your summary.
 
-1. What should this skill enable OpenCode to do?
-2. When should this skill trigger? (what user phrases/contexts)
-3. What's the expected output format?
-4. Should we set up test cases to verify the skill works? Skills with objectively verifiable outputs (file transforms, data extraction, code generation, fixed workflow steps) benefit from test cases. Skills with subjective outputs (writing style, art) often don't need them. Suggest the appropriate default based on the skill type, but let the user decide.
+Start by understanding the user's intent. The current conversation might already contain part of the workflow the user wants to capture (e.g., they say "turn this into a skill"). Extract that first: tools used, sequence of steps, corrections, inputs/outputs, and success criteria. Then fill the gaps with questions.
+
+Ask at least 3-5 targeted questions (more when needed). Cover these minimum areas:
+
+1. What should this skill enable OpenCode to do end-to-end?
+2. When should this skill trigger? (phrases, contexts, near-misses)
+3. What output format and quality bar are expected?
+4. What workflow steps must be preserved exactly vs. where can the agent improvise?
+5. Should we set up test cases to verify behavior? Skills with objectively verifiable outputs (file transforms, data extraction, code generation, fixed workflow steps) benefit from test cases. Skills with subjective outputs (writing style, art) often don't need them. Suggest the appropriate default based on skill type, then let the user decide.
+
+Before moving on, summarize your understanding in plain language and ask the user to confirm or correct it.
+
+If the user explicitly asks to skip intake, warn that final quality and workflow fit will likely be worse. Proceed only after explicit confirmation.
 
 ### Interview and Research
 
-Proactively ask questions about edge cases, input/output formats, example files, success criteria, and dependencies. Wait to write test prompts until you've got this part ironed out.
+Proactively ask questions about edge cases, input/output formats, example files, success criteria, and dependencies. Use a buddy/shadowing stance: mirror the user's real workflow, terminology, handoffs, and decision points. Wait to write test prompts until you've got this part ironed out.
 
 Check available MCPs — if useful for research (searching docs, finding similar skills, looking up best practices), research in parallel via the Task tool (using `general` or `explore` subagent types) if available, otherwise inline. Come prepared with context to reduce burden on the user.
 


### PR DESCRIPTION
## Summary
- Enforce mandatory intake interview (3-5+ questions) for new skills in both source and bundled `SKILL.md`, including explicit quality warning when skipped.
- Improve evaluation reliability and parity defaults: switch eval/improve subprocesses to `opencode run --format json`, parse structured events for trigger/text detection, and default eval runs to 3 with Claude-aligned workers/timeouts.
- Tighten plugin behavior and metadata: return full `content` from `skill_parse`, auto-update bundled `skill-creator` on plugin version changes, and compute `runs_per_configuration` dynamically in benchmark aggregation.

## Validation
- `bun -e "import('./plugin/lib/run-eval.ts').then(() => console.log('run-eval ok'))"`
- `bun -e "import('./plugin/lib/aggregate.ts').then(() => console.log('aggregate ok'))"`
- `bun -e "import('./plugin/lib/improve-description.ts').then(() => console.log('improve-description ok'))"`
- `bun -e "import('./plugin/skill-creator.ts').then(() => console.log('plugin ok'))"`
- `diff -rq skill-creator plugin/skill` (no differences)