### PR TITLE
Automate release bumps and publish v0.2.6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,11 +18,47 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Read plugin version
+      - name: Resolve release version
         id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+
           VERSION=$(node -p 'require("./plugin/package.json").version')
+          TAG="v${VERSION}"
+
+          npm_exists=false
+          release_exists=false
+
+          if npm view "opencode-skill-creator@${VERSION}" version >/dev/null 2>&1; then
+            npm_exists=true
+          fi
+
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            release_exists=true
+          fi
+
+          # Auto-bump patch when both npm and GitHub already have this version.
+          # This keeps release automation fully hands-off on each merge to main.
+          if [[ "$npm_exists" == "true" && "$release_exists" == "true" ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+            pushd plugin >/dev/null
+            npm version patch --no-git-tag-version
+            VERSION=$(node -p 'require("./package.json").version')
+            popd >/dev/null
+
+            git add plugin/package.json
+            git commit -m "chore(release): bump version to v${VERSION} [skip ci]"
+            git push
+            TAG="v${VERSION}"
+          fi
+
           echo "value=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "target_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Check npm version
         id: npm
@@ -46,7 +82,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          TAG="v${{ steps.version.outputs.value }}"
+          TAG="${{ steps.version.outputs.tag }}"
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
@@ -58,8 +94,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          TAG="v${{ steps.version.outputs.value }}"
+          TAG="${{ steps.version.outputs.tag }}"
           gh release create "$TAG" \
-            --target "${{ github.sha }}" \
+            --target "${{ steps.version.outputs.target_sha }}" \
             --title "$TAG" \
             --notes "Automated release for opencode-skill-creator $TAG"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-and-publish:
     runs-on: ubuntu-latest
@@ -52,7 +56,7 @@ jobs:
 
             git add plugin/package.json
             git commit -m "chore(release): bump version to v${VERSION} [skip ci]"
-            git push
+            git push origin "HEAD:${GITHUB_REF_NAME}"
             TAG="v${VERSION}"
           fi
 

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-skill-creator",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "OpenCode plugin for skill creation — custom tools for validation, evaluation, description optimization, benchmarking, and review serving.",
   "type": "module",
   "main": "./skill-creator.ts",


### PR DESCRIPTION
## Summary
- Add release workflow logic to auto-bump the plugin patch version when the current version/tag already exist on npm and GitHub, then continue publish/release with the bumped version.
- Switch release tag/target wiring to use resolved step outputs so GitHub release points at the exact commit/version chosen by the workflow.
- Bump `plugin/package.json` version from `0.2.5` to `0.2.6` so next merge to `main` publishes a new npm package and release.

## Why
The previous workflow intentionally skipped publish/release when `plugin/package.json` matched an already-published version. This change removes that manual bottleneck and keeps main-branch merges releasable without hand-updating version/tag first.