### PR TITLE
Enforce strict review workflow and auto-benchmark generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,17 @@ The plugin registers these custom tools that OpenCode can call:
 | `skill_stop_review` | Stop a running review server |
 | `skill_export_static_review` | Generate standalone HTML review file |
 
+### Review workflow guard (strict by default)
+
+The review launch tools now enforce paired comparison data by default:
+
+- `skill_serve_review` and `skill_export_static_review` require each `eval-*` directory to include:
+  - `with_skill`
+  - baseline (`without_skill` or `old_skill`)
+- If pairs are missing, the tools fail fast with a clear list of missing items.
+- Override only when intentionally reviewing partial data by passing `allowPartial: true`.
+- If `benchmarkPath` is omitted, the tools auto-generate `benchmark.json` and `benchmark.md` in the workspace.
+
 ## Usage
 
 Once installed, OpenCode will automatically detect the skill when you ask it to create or improve a skill. For example:

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -216,6 +216,17 @@ The plugin registers these custom tools that OpenCode can call:
 | `skill_stop_review` | Stop a running review server |
 | `skill_export_static_review` | Generate standalone HTML review file |
 
+### Review workflow guard (strict by default)
+
+The review launch tools now enforce paired comparison data by default:
+
+- `skill_serve_review` and `skill_export_static_review` require each `eval-*` directory to include:
+  - `with_skill`
+  - baseline (`without_skill` or `old_skill`)
+- If pairs are missing, the tools fail fast with a clear list of missing items.
+- Override only when intentionally reviewing partial data by passing `allowPartial: true`.
+- If `benchmarkPath` is omitted, the tools auto-generate `benchmark.json` and `benchmark.md` in the workspace.
+
 ## Usage
 
 Once installed, OpenCode will automatically detect the skill when you ask it to create or improve a skill. For example:

--- a/plugin/lib/aggregate.ts
+++ b/plugin/lib/aggregate.ts
@@ -297,6 +297,15 @@ function aggregateResults(
   const runSummary: Record<string, unknown> = {}
   const configs = Object.keys(results)
 
+  if (configs.length === 0) {
+    runSummary.delta = {
+      pass_rate: "+0.00",
+      time_seconds: "+0.0",
+      tokens: "+0",
+    }
+    return runSummary
+  }
+
   for (const config of configs) {
     const runs = results[config] ?? []
     if (runs.length === 0) {
@@ -427,11 +436,17 @@ export function generateMarkdown(benchmark: BenchmarkOutput): string {
   ]
 
   const fmtPR = (s: any) =>
-    s ? `${(s.mean * 100).toFixed(0)}% ± ${(s.stddev * 100).toFixed(0)}%` : "—"
+    s && typeof s.mean === "number" && typeof s.stddev === "number"
+      ? `${(s.mean * 100).toFixed(0)}% ± ${(s.stddev * 100).toFixed(0)}%`
+      : "—"
   const fmtTime = (s: any) =>
-    s ? `${s.mean.toFixed(1)}s ± ${s.stddev.toFixed(1)}s` : "—"
+    s && typeof s.mean === "number" && typeof s.stddev === "number"
+      ? `${s.mean.toFixed(1)}s ± ${s.stddev.toFixed(1)}s`
+      : "—"
   const fmtTokens = (s: any) =>
-    s ? `${s.mean.toFixed(0)} ± ${s.stddev.toFixed(0)}` : "—"
+    s && typeof s.mean === "number" && typeof s.stddev === "number"
+      ? `${s.mean.toFixed(0)} ± ${s.stddev.toFixed(0)}`
+      : "—"
 
   lines.push(
     `| Pass Rate | ${fmtPR(a.pass_rate)} | ${fmtPR(b.pass_rate)} | ${delta.pass_rate ?? "—"} |`,

--- a/plugin/lib/workflow-guard.ts
+++ b/plugin/lib/workflow-guard.ts
@@ -45,6 +45,36 @@ export function validateComparisonWorkspace(
   const issues: WorkflowValidationIssue[] = []
   const foundConfigs = new Set<string>()
 
+  if (!existsSync(workspace)) {
+    return {
+      valid: false,
+      evalCount: 0,
+      issues: [
+        {
+          evalDir: basename(workspace),
+          issue: "workspace path does not exist",
+        },
+      ],
+      foundConfigs: [],
+      searchRoot: workspace,
+    }
+  }
+
+  if (!statSync(workspace).isDirectory()) {
+    return {
+      valid: false,
+      evalCount: 0,
+      issues: [
+        {
+          evalDir: basename(workspace),
+          issue: "workspace path is not a directory",
+        },
+      ],
+      foundConfigs: [],
+      searchRoot: workspace,
+    }
+  }
+
   let searchRoot = workspace
   let evalDirs = sortedDirs(searchRoot, /^eval-/)
   if (evalDirs.length === 0) {

--- a/plugin/lib/workflow-guard.ts
+++ b/plugin/lib/workflow-guard.ts
@@ -1,0 +1,118 @@
+/**
+ * Workflow guard helpers for eval review launch.
+ *
+ * Enforces paired with-skill/baseline run structure before opening the review
+ * viewer, unless explicitly overridden.
+ */
+
+import { existsSync, readdirSync, statSync } from "fs"
+import { basename, join } from "path"
+
+function sortedDirs(dir: string, pattern?: RegExp): string[] {
+  if (!existsSync(dir) || !statSync(dir).isDirectory()) return []
+  return readdirSync(dir)
+    .map((name) => join(dir, name))
+    .filter((full) => statSync(full).isDirectory())
+    .filter((full) => (pattern ? pattern.test(basename(full)) : true))
+    .sort()
+}
+
+function hasAtLeastOneRun(configDir: string): boolean {
+  const runDirs = sortedDirs(configDir, /^run-/)
+  if (runDirs.length > 0) return true
+
+  // Common task-output layout when run-N folders were not created.
+  const outputsDir = join(configDir, "outputs")
+  return existsSync(outputsDir) && statSync(outputsDir).isDirectory()
+}
+
+export interface WorkflowValidationIssue {
+  evalDir: string
+  issue: string
+}
+
+export interface WorkflowValidationResult {
+  valid: boolean
+  evalCount: number
+  issues: WorkflowValidationIssue[]
+  foundConfigs: string[]
+  searchRoot: string
+}
+
+export function validateComparisonWorkspace(
+  workspace: string,
+): WorkflowValidationResult {
+  const issues: WorkflowValidationIssue[] = []
+  const foundConfigs = new Set<string>()
+
+  let searchRoot = workspace
+  let evalDirs = sortedDirs(searchRoot, /^eval-/)
+  if (evalDirs.length === 0) {
+    const runsRoot = join(workspace, "runs")
+    const nested = sortedDirs(runsRoot, /^eval-/)
+    if (nested.length > 0) {
+      searchRoot = runsRoot
+      evalDirs = nested
+    }
+  }
+
+  if (evalDirs.length === 0) {
+    issues.push({
+      evalDir: basename(workspace),
+      issue: "no eval-* directories found (expected evals with with_skill and baseline runs)",
+    })
+  }
+
+  for (const evalDir of evalDirs) {
+    const withSkillDir = join(evalDir, "with_skill")
+    const withoutSkillDir = join(evalDir, "without_skill")
+    const oldSkillDir = join(evalDir, "old_skill")
+
+    if (existsSync(withSkillDir) && statSync(withSkillDir).isDirectory()) {
+      foundConfigs.add("with_skill")
+    }
+    if (existsSync(withoutSkillDir) && statSync(withoutSkillDir).isDirectory()) {
+      foundConfigs.add("without_skill")
+    }
+    if (existsSync(oldSkillDir) && statSync(oldSkillDir).isDirectory()) {
+      foundConfigs.add("old_skill")
+    }
+
+    const hasWithSkill =
+      existsSync(withSkillDir) &&
+      statSync(withSkillDir).isDirectory() &&
+      hasAtLeastOneRun(withSkillDir)
+
+    const hasWithoutSkill =
+      existsSync(withoutSkillDir) &&
+      statSync(withoutSkillDir).isDirectory() &&
+      hasAtLeastOneRun(withoutSkillDir)
+
+    const hasOldSkill =
+      existsSync(oldSkillDir) &&
+      statSync(oldSkillDir).isDirectory() &&
+      hasAtLeastOneRun(oldSkillDir)
+
+    if (!hasWithSkill) {
+      issues.push({
+        evalDir: basename(evalDir),
+        issue: "missing with_skill run outputs",
+      })
+    }
+
+    if (!hasWithoutSkill && !hasOldSkill) {
+      issues.push({
+        evalDir: basename(evalDir),
+        issue: "missing baseline run outputs (without_skill or old_skill)",
+      })
+    }
+  }
+
+  return {
+    valid: issues.length === 0,
+    evalCount: evalDirs.length,
+    issues,
+    foundConfigs: [...foundConfigs].sort(),
+    searchRoot,
+  }
+}

--- a/plugin/skill-creator.ts
+++ b/plugin/skill-creator.ts
@@ -36,6 +36,7 @@ import { runLoop } from "./lib/run-loop"
 import { generateBenchmark, generateMarkdown } from "./lib/aggregate"
 import { generateHtml as generateReportHtml } from "./lib/report"
 import { serveReview, exportStaticReview } from "./lib/review-server"
+import { validateComparisonWorkspace } from "./lib/workflow-guard"
 
 import type { EvalItem } from "./lib/run-eval"
 
@@ -516,8 +517,46 @@ export const SkillCreatorPlugin: Plugin = async (ctx) => {
             .string()
             .optional()
             .describe("Path to benchmark.json for the Benchmark tab"),
+          allowPartial: tool.schema
+            .boolean()
+            .optional()
+            .describe("Allow launching review even if with_skill/baseline run pairs are incomplete (default: false)"),
         },
         async execute(args) {
+          const { writeFileSync } = await import("fs")
+
+          const strictMode = !(args.allowPartial ?? false)
+          const validation = validateComparisonWorkspace(args.workspace)
+          if (strictMode && !validation.valid) {
+            const issueLines = validation.issues.map(
+              (issue) => `- ${issue.evalDir}: ${issue.issue}`,
+            )
+
+            throw new Error(
+              [
+                `Strict review preflight failed for ${args.workspace}.`,
+                "Missing required with_skill/baseline pairs:",
+                ...issueLines,
+                "Run missing eval pairs first, or set allowPartial=true to override.",
+              ].join("\n"),
+            )
+          }
+
+          // Auto-generate benchmark when omitted so the viewer always has a Benchmark tab.
+          let resolvedBenchmarkPath = args.benchmarkPath ?? null
+          if (!resolvedBenchmarkPath) {
+            const benchmark = generateBenchmark(
+              args.workspace,
+              args.skillName ?? "",
+              "",
+            )
+            const jsonPath = join(args.workspace, "benchmark.json")
+            const mdPath = join(args.workspace, "benchmark.md")
+            writeFileSync(jsonPath, JSON.stringify(benchmark, null, 2))
+            writeFileSync(mdPath, generateMarkdown(benchmark))
+            resolvedBenchmarkPath = jsonPath
+          }
+
           // Stop any existing server for this workspace
           const existing = activeServers.get(args.workspace)
           if (existing) {
@@ -532,7 +571,7 @@ export const SkillCreatorPlugin: Plugin = async (ctx) => {
             port: args.port ?? 3117,
             skillName: args.skillName,
             previousWorkspace: args.previousWorkspace ?? null,
-            benchmarkPath: args.benchmarkPath ?? null,
+            benchmarkPath: resolvedBenchmarkPath,
             templatePath,
             openBrowser: true,
           })
@@ -542,6 +581,14 @@ export const SkillCreatorPlugin: Plugin = async (ctx) => {
           return JSON.stringify({
             url,
             feedbackPath,
+            benchmarkPath: resolvedBenchmarkPath,
+            workflowGuard: {
+              strictMode,
+              allowPartial: args.allowPartial ?? false,
+              evalCount: validation.evalCount,
+              foundConfigs: validation.foundConfigs,
+              issues: validation.issues,
+            },
             message: `Eval viewer running at ${url}. Press Ctrl+C or call skill_stop_review to stop.`,
           })
         },
@@ -605,8 +652,45 @@ export const SkillCreatorPlugin: Plugin = async (ctx) => {
             .string()
             .optional()
             .describe("Path to benchmark.json"),
+          allowPartial: tool.schema
+            .boolean()
+            .optional()
+            .describe("Allow exporting review even if with_skill/baseline run pairs are incomplete (default: false)"),
         },
         async execute(args) {
+          const { writeFileSync } = await import("fs")
+
+          const strictMode = !(args.allowPartial ?? false)
+          const validation = validateComparisonWorkspace(args.workspace)
+          if (strictMode && !validation.valid) {
+            const issueLines = validation.issues.map(
+              (issue) => `- ${issue.evalDir}: ${issue.issue}`,
+            )
+
+            throw new Error(
+              [
+                `Strict review preflight failed for ${args.workspace}.`,
+                "Missing required with_skill/baseline pairs:",
+                ...issueLines,
+                "Run missing eval pairs first, or set allowPartial=true to override.",
+              ].join("\n"),
+            )
+          }
+
+          let resolvedBenchmarkPath = args.benchmarkPath ?? null
+          if (!resolvedBenchmarkPath) {
+            const benchmark = generateBenchmark(
+              args.workspace,
+              args.skillName ?? "",
+              "",
+            )
+            const jsonPath = join(args.workspace, "benchmark.json")
+            const mdPath = join(args.workspace, "benchmark.md")
+            writeFileSync(jsonPath, JSON.stringify(benchmark, null, 2))
+            writeFileSync(mdPath, generateMarkdown(benchmark))
+            resolvedBenchmarkPath = jsonPath
+          }
+
           const templatePath = join(TEMPLATES_DIR, "viewer.html")
 
           const outPath = exportStaticReview({
@@ -614,12 +698,20 @@ export const SkillCreatorPlugin: Plugin = async (ctx) => {
             outputPath: args.outputPath,
             skillName: args.skillName,
             previousWorkspace: args.previousWorkspace ?? null,
-            benchmarkPath: args.benchmarkPath ?? null,
+            benchmarkPath: resolvedBenchmarkPath,
             templatePath,
           })
 
           return JSON.stringify({
             outputPath: outPath,
+            benchmarkPath: resolvedBenchmarkPath,
+            workflowGuard: {
+              strictMode,
+              allowPartial: args.allowPartial ?? false,
+              evalCount: validation.evalCount,
+              foundConfigs: validation.foundConfigs,
+              issues: validation.issues,
+            },
             message: `Static viewer written to ${outPath}`,
           })
         },

--- a/plugin/skill-creator.ts
+++ b/plugin/skill-creator.ts
@@ -89,9 +89,9 @@ function prepareReviewLaunch(args: {
     throw new Error(
       [
         `Strict review preflight failed for ${args.workspace}.`,
-        "Missing required with_skill/baseline pairs:",
+        "Preflight issues:",
         ...issueLines,
-        "Run missing eval pairs first, or set allowPartial=true to override.",
+        "Resolve the issues above, or set allowPartial=true to override.",
       ].join("\n"),
     )
   }

--- a/plugin/skill-creator.ts
+++ b/plugin/skill-creator.ts
@@ -65,6 +65,63 @@ const PACKAGE_VERSION = (() => {
   }
 })()
 
+interface ReviewPrepResult {
+  strictMode: boolean
+  allowPartial: boolean
+  validation: ReturnType<typeof validateComparisonWorkspace>
+  benchmarkPath: string | null
+}
+
+function prepareReviewLaunch(args: {
+  workspace: string
+  skillName?: string
+  benchmarkPath?: string
+  allowPartial?: boolean
+}): ReviewPrepResult {
+  const strictMode = !(args.allowPartial ?? false)
+  const validation = validateComparisonWorkspace(args.workspace)
+
+  if (strictMode && !validation.valid) {
+    const issueLines = validation.issues.map(
+      (issue) => `- ${issue.evalDir}: ${issue.issue}`,
+    )
+
+    throw new Error(
+      [
+        `Strict review preflight failed for ${args.workspace}.`,
+        "Missing required with_skill/baseline pairs:",
+        ...issueLines,
+        "Run missing eval pairs first, or set allowPartial=true to override.",
+      ].join("\n"),
+    )
+  }
+
+  let resolvedBenchmarkPath = args.benchmarkPath ?? null
+  if (!resolvedBenchmarkPath) {
+    try {
+      const benchmark = generateBenchmark(
+        args.workspace,
+        args.skillName ?? "",
+        "",
+      )
+      const jsonPath = join(args.workspace, "benchmark.json")
+      const mdPath = join(args.workspace, "benchmark.md")
+      writeFileSync(jsonPath, JSON.stringify(benchmark, null, 2))
+      writeFileSync(mdPath, generateMarkdown(benchmark))
+      resolvedBenchmarkPath = jsonPath
+    } catch {
+      resolvedBenchmarkPath = null
+    }
+  }
+
+  return {
+    strictMode,
+    allowPartial: args.allowPartial ?? false,
+    validation,
+    benchmarkPath: resolvedBenchmarkPath,
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Auto-install: copy bundled skill files to the global skills directory
 // ---------------------------------------------------------------------------
@@ -523,39 +580,7 @@ export const SkillCreatorPlugin: Plugin = async (ctx) => {
             .describe("Allow launching review even if with_skill/baseline run pairs are incomplete (default: false)"),
         },
         async execute(args) {
-          const { writeFileSync } = await import("fs")
-
-          const strictMode = !(args.allowPartial ?? false)
-          const validation = validateComparisonWorkspace(args.workspace)
-          if (strictMode && !validation.valid) {
-            const issueLines = validation.issues.map(
-              (issue) => `- ${issue.evalDir}: ${issue.issue}`,
-            )
-
-            throw new Error(
-              [
-                `Strict review preflight failed for ${args.workspace}.`,
-                "Missing required with_skill/baseline pairs:",
-                ...issueLines,
-                "Run missing eval pairs first, or set allowPartial=true to override.",
-              ].join("\n"),
-            )
-          }
-
-          // Auto-generate benchmark when omitted so the viewer always has a Benchmark tab.
-          let resolvedBenchmarkPath = args.benchmarkPath ?? null
-          if (!resolvedBenchmarkPath) {
-            const benchmark = generateBenchmark(
-              args.workspace,
-              args.skillName ?? "",
-              "",
-            )
-            const jsonPath = join(args.workspace, "benchmark.json")
-            const mdPath = join(args.workspace, "benchmark.md")
-            writeFileSync(jsonPath, JSON.stringify(benchmark, null, 2))
-            writeFileSync(mdPath, generateMarkdown(benchmark))
-            resolvedBenchmarkPath = jsonPath
-          }
+          const prep = prepareReviewLaunch(args)
 
           // Stop any existing server for this workspace
           const existing = activeServers.get(args.workspace)
@@ -571,7 +596,7 @@ export const SkillCreatorPlugin: Plugin = async (ctx) => {
             port: args.port ?? 3117,
             skillName: args.skillName,
             previousWorkspace: args.previousWorkspace ?? null,
-            benchmarkPath: resolvedBenchmarkPath,
+            benchmarkPath: prep.benchmarkPath,
             templatePath,
             openBrowser: true,
           })
@@ -581,13 +606,13 @@ export const SkillCreatorPlugin: Plugin = async (ctx) => {
           return JSON.stringify({
             url,
             feedbackPath,
-            benchmarkPath: resolvedBenchmarkPath,
+            benchmarkPath: prep.benchmarkPath,
             workflowGuard: {
-              strictMode,
-              allowPartial: args.allowPartial ?? false,
-              evalCount: validation.evalCount,
-              foundConfigs: validation.foundConfigs,
-              issues: validation.issues,
+              strictMode: prep.strictMode,
+              allowPartial: prep.allowPartial,
+              evalCount: prep.validation.evalCount,
+              foundConfigs: prep.validation.foundConfigs,
+              issues: prep.validation.issues,
             },
             message: `Eval viewer running at ${url}. Press Ctrl+C or call skill_stop_review to stop.`,
           })
@@ -658,38 +683,7 @@ export const SkillCreatorPlugin: Plugin = async (ctx) => {
             .describe("Allow exporting review even if with_skill/baseline run pairs are incomplete (default: false)"),
         },
         async execute(args) {
-          const { writeFileSync } = await import("fs")
-
-          const strictMode = !(args.allowPartial ?? false)
-          const validation = validateComparisonWorkspace(args.workspace)
-          if (strictMode && !validation.valid) {
-            const issueLines = validation.issues.map(
-              (issue) => `- ${issue.evalDir}: ${issue.issue}`,
-            )
-
-            throw new Error(
-              [
-                `Strict review preflight failed for ${args.workspace}.`,
-                "Missing required with_skill/baseline pairs:",
-                ...issueLines,
-                "Run missing eval pairs first, or set allowPartial=true to override.",
-              ].join("\n"),
-            )
-          }
-
-          let resolvedBenchmarkPath = args.benchmarkPath ?? null
-          if (!resolvedBenchmarkPath) {
-            const benchmark = generateBenchmark(
-              args.workspace,
-              args.skillName ?? "",
-              "",
-            )
-            const jsonPath = join(args.workspace, "benchmark.json")
-            const mdPath = join(args.workspace, "benchmark.md")
-            writeFileSync(jsonPath, JSON.stringify(benchmark, null, 2))
-            writeFileSync(mdPath, generateMarkdown(benchmark))
-            resolvedBenchmarkPath = jsonPath
-          }
+          const prep = prepareReviewLaunch(args)
 
           const templatePath = join(TEMPLATES_DIR, "viewer.html")
 
@@ -698,19 +692,19 @@ export const SkillCreatorPlugin: Plugin = async (ctx) => {
             outputPath: args.outputPath,
             skillName: args.skillName,
             previousWorkspace: args.previousWorkspace ?? null,
-            benchmarkPath: resolvedBenchmarkPath,
+            benchmarkPath: prep.benchmarkPath,
             templatePath,
           })
 
           return JSON.stringify({
             outputPath: outPath,
-            benchmarkPath: resolvedBenchmarkPath,
+            benchmarkPath: prep.benchmarkPath,
             workflowGuard: {
-              strictMode,
-              allowPartial: args.allowPartial ?? false,
-              evalCount: validation.evalCount,
-              foundConfigs: validation.foundConfigs,
-              issues: validation.issues,
+              strictMode: prep.strictMode,
+              allowPartial: prep.allowPartial,
+              evalCount: prep.validation.evalCount,
+              foundConfigs: prep.validation.foundConfigs,
+              issues: prep.validation.issues,
             },
             message: `Static viewer written to ${outPath}`,
           })

--- a/plugin/skill/SKILL.md
+++ b/plugin/skill/SKILL.md
@@ -235,6 +235,8 @@ This is the only opportunity to capture this data — it comes through the task 
 
 Once all runs are done:
 
+Before launching review, enforce this gate: every eval must have paired comparison outputs (`with_skill` plus one baseline: `without_skill` or `old_skill`). Do not continue to review if pairs are missing unless the user explicitly asks to proceed with partial data.
+
 1. **Grade each run** — spawn a grader Task (using `general` subagent type), or grade inline, that reads `agents/grader.md` and evaluates each assertion against the outputs. Save results to `grading.json` in each run directory. The grading.json expectations array must use the fields `text`, `passed`, and `evidence` (not `name`/`met`/`details` or other variants) — the viewer depends on these exact field names. For assertions that can be checked programmatically, write and run a script rather than eyeballing it — scripts are faster, more reliable, and can be reused across iterations.
 
 2. **Aggregate into benchmark** — use the `skill_aggregate_benchmark` tool:
@@ -254,8 +256,13 @@ Put each with_skill version before its baseline counterpart.
      workspace: <workspace>/iteration-N
      skillName: "my-skill"
      benchmarkPath: <workspace>/iteration-N/benchmark.json
+     allowPartial: false
    ```
    For iteration 2+, also pass `previousWorkspace: <workspace>/iteration-<N-1>`.
+
+   If `benchmarkPath` is omitted, the tool auto-generates `benchmark.json` and `benchmark.md` inside the workspace before opening the viewer.
+
+   The default is strict (`allowPartial: false`): it fails fast when eval pairs are incomplete. Use `allowPartial: true` only when the user explicitly accepts incomplete comparisons.
 
    **Headless environments:** Use the `skill_export_static_review` tool to write a standalone HTML file instead of starting a server. Feedback will be downloaded as a `feedback.json` file when the user clicks "Submit All Reviews". After download, copy `feedback.json` into the workspace directory for the next iteration to pick up.
 

--- a/skill-creator/SKILL.md
+++ b/skill-creator/SKILL.md
@@ -235,6 +235,8 @@ This is the only opportunity to capture this data — it comes through the task 
 
 Once all runs are done:
 
+Before launching review, enforce this gate: every eval must have paired comparison outputs (`with_skill` plus one baseline: `without_skill` or `old_skill`). Do not continue to review if pairs are missing unless the user explicitly asks to proceed with partial data.
+
 1. **Grade each run** — spawn a grader Task (using `general` subagent type), or grade inline, that reads `agents/grader.md` and evaluates each assertion against the outputs. Save results to `grading.json` in each run directory. The grading.json expectations array must use the fields `text`, `passed`, and `evidence` (not `name`/`met`/`details` or other variants) — the viewer depends on these exact field names. For assertions that can be checked programmatically, write and run a script rather than eyeballing it — scripts are faster, more reliable, and can be reused across iterations.
 
 2. **Aggregate into benchmark** — use the `skill_aggregate_benchmark` tool:
@@ -254,8 +256,13 @@ Put each with_skill version before its baseline counterpart.
      workspace: <workspace>/iteration-N
      skillName: "my-skill"
      benchmarkPath: <workspace>/iteration-N/benchmark.json
+     allowPartial: false
    ```
    For iteration 2+, also pass `previousWorkspace: <workspace>/iteration-<N-1>`.
+
+   If `benchmarkPath` is omitted, the tool auto-generates `benchmark.json` and `benchmark.md` inside the workspace before opening the viewer.
+
+   The default is strict (`allowPartial: false`): it fails fast when eval pairs are incomplete. Use `allowPartial: true` only when the user explicitly accepts incomplete comparisons.
 
    **Headless environments:** Use the `skill_export_static_review` tool to write a standalone HTML file instead of starting a server. Feedback will be downloaded as a `feedback.json` file when the user clicks "Submit All Reviews". After download, copy `feedback.json` into the workspace directory for the next iteration to pick up.
 


### PR DESCRIPTION
## Summary
- Add strict workflow preflight validation for review launch tools so each eval must include paired comparison outputs (`with_skill` + baseline `without_skill` or `old_skill`) unless explicitly overridden with `allowPartial: true`.
- Auto-generate `benchmark.json` and `benchmark.md` inside the workspace when `skill_serve_review` / `skill_export_static_review` are called without a `benchmarkPath`, ensuring the Benchmark tab is always populated.
- Update both skill instruction copies and READMEs to document the strict-by-default comparison gate and the explicit partial-data override path.

## Validation
- `bun -e "import('./plugin/lib/workflow-guard.ts').then(() => console.log('workflow-guard ok'))"`
- `bun -e "import('./plugin/skill-creator.ts').then(() => console.log('plugin ok'))"`
- `diff -rq skill-creator plugin/skill` (no differences)