### PR TITLE
Fix review/optimizer runtime errors and default skill drafting to staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Skill creator eval/review generated artifacts
+*-workspace/
+**/*-workspace/
+
+# Review and benchmark outputs
+**/benchmark.json
+**/benchmark.md
+**/feedback.json
+**/review.html
+**/eval_review*.html
+
+# Optimizer and eval logs
+**/improve_iter_*.json
+**/optimization-results*.json
+**/trigger-eval*.json
+
+# Local temp/export artifacts
+tmp/
+*.tmp

--- a/README.md
+++ b/README.md
@@ -229,10 +229,11 @@ The review launch tools now enforce paired comparison data by default:
 
 ### Skill draft staging (recommended)
 
-When creating new skills, use a staging path outside your current repository by default:
+When creating new skills, use a staging path in the system temp directory outside your current repository:
 
-- Draft skill path: `/tmp/opencode-skills/<skill-name>/`
-- Eval workspace path: `/tmp/opencode-skills/<skill-name>-workspace/`
+- Unix/macOS draft skill path: `/tmp/opencode-skills/<skill-name>/` (or `$TMPDIR/opencode-skills/<skill-name>/`)
+- Unix/macOS eval workspace path: `/tmp/opencode-skills/<skill-name>-workspace/`
+- Windows draft/eval paths: `%TEMP%\\opencode-skills\\<skill-name>\\` and `%TEMP%\\opencode-skills\\<skill-name>-workspace\\`
 - Install only the final validated skill to:
   - project: `.opencode/skills/<skill-name>/`
   - global: `~/.config/opencode/skills/<skill-name>/`

--- a/README.md
+++ b/README.md
@@ -227,6 +227,18 @@ The review launch tools now enforce paired comparison data by default:
 - Override only when intentionally reviewing partial data by passing `allowPartial: true`.
 - If `benchmarkPath` is omitted, the tools auto-generate `benchmark.json` and `benchmark.md` in the workspace.
 
+### Skill draft staging (recommended)
+
+When creating new skills, use a staging path outside your current repository by default:
+
+- Draft skill path: `/tmp/opencode-skills/<skill-name>/`
+- Eval workspace path: `/tmp/opencode-skills/<skill-name>-workspace/`
+- Install only the final validated skill to:
+  - project: `.opencode/skills/<skill-name>/`
+  - global: `~/.config/opencode/skills/<skill-name>/`
+
+This keeps plugin/source repositories clean while preserving the full eval loop.
+
 ## Usage
 
 Once installed, OpenCode will automatically detect the skill when you ask it to create or improve a skill. For example:

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -229,10 +229,11 @@ The review launch tools now enforce paired comparison data by default:
 
 ### Skill draft staging (recommended)
 
-When creating new skills, use a staging path outside your current repository by default:
+When creating new skills, use a staging path in the system temp directory outside your current repository:
 
-- Draft skill path: `/tmp/opencode-skills/<skill-name>/`
-- Eval workspace path: `/tmp/opencode-skills/<skill-name>-workspace/`
+- Unix/macOS draft skill path: `/tmp/opencode-skills/<skill-name>/` (or `$TMPDIR/opencode-skills/<skill-name>/`)
+- Unix/macOS eval workspace path: `/tmp/opencode-skills/<skill-name>-workspace/`
+- Windows draft/eval paths: `%TEMP%\\opencode-skills\\<skill-name>\\` and `%TEMP%\\opencode-skills\\<skill-name>-workspace\\`
 - Install only the final validated skill to:
   - project: `.opencode/skills/<skill-name>/`
   - global: `~/.config/opencode/skills/<skill-name>/`

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -227,6 +227,18 @@ The review launch tools now enforce paired comparison data by default:
 - Override only when intentionally reviewing partial data by passing `allowPartial: true`.
 - If `benchmarkPath` is omitted, the tools auto-generate `benchmark.json` and `benchmark.md` in the workspace.
 
+### Skill draft staging (recommended)
+
+When creating new skills, use a staging path outside your current repository by default:
+
+- Draft skill path: `/tmp/opencode-skills/<skill-name>/`
+- Eval workspace path: `/tmp/opencode-skills/<skill-name>-workspace/`
+- Install only the final validated skill to:
+  - project: `.opencode/skills/<skill-name>/`
+  - global: `~/.config/opencode/skills/<skill-name>/`
+
+This keeps plugin/source repositories clean while preserving the full eval loop.
+
 ## Usage
 
 Once installed, OpenCode will automatically detect the skill when you ask it to create or improve a skill. For example:

--- a/plugin/lib/improve-description.ts
+++ b/plugin/lib/improve-description.ts
@@ -34,7 +34,9 @@ async function callOpenCode(
   try {
     const cmd = ["opencode", "run", "--format", "json"]
     if (model) cmd.push("--model", model)
-    cmd.push("--file", tmpPath, "Process the attached file and follow its instructions.")
+    // Use `--` to terminate option parsing so the trailing prompt is treated
+    // as a positional message instead of another --file value.
+    cmd.push("--file", tmpPath, "--", "Process the attached file and follow its instructions.")
 
     const proc = Bun.spawn(cmd, {
       stdout: "pipe",

--- a/plugin/lib/review-server.ts
+++ b/plugin/lib/review-server.ts
@@ -469,28 +469,38 @@ export async function serveReview(opts: ServeReviewOptions): Promise<{
       }
 
       if (req.method === "POST" && url.pathname === "/api/feedback") {
+        let body: unknown
         try {
-          const body = (await req.json()) as unknown
-          if (typeof body !== "object" || body === null || !("reviews" in body)) {
-            return new Response(
-              JSON.stringify({ error: "Expected JSON object with 'reviews' key" }),
-              {
-                status: 400,
-                headers: { "Content-Type": "application/json" },
-              },
-            )
-          }
-
-          writeFileSync(feedbackPath, JSON.stringify(body, null, 2) + "\n")
-          return new Response(JSON.stringify({ ok: true }), {
-            headers: { "Content-Type": "application/json" },
-          })
+          body = (await req.json()) as unknown
         } catch (e) {
           return new Response(JSON.stringify({ error: String(e) }), {
             status: 400,
             headers: { "Content-Type": "application/json" },
           })
         }
+
+        if (typeof body !== "object" || body === null || !("reviews" in body)) {
+          return new Response(
+            JSON.stringify({ error: "Expected JSON object with 'reviews' key" }),
+            {
+              status: 400,
+              headers: { "Content-Type": "application/json" },
+            },
+          )
+        }
+
+        try {
+          writeFileSync(feedbackPath, JSON.stringify(body, null, 2) + "\n")
+        } catch (e) {
+          return new Response(JSON.stringify({ error: String(e) }), {
+            status: 500,
+            headers: { "Content-Type": "application/json" },
+          })
+        }
+
+        return new Response(JSON.stringify({ ok: true }), {
+          headers: { "Content-Type": "application/json" },
+        })
       }
 
       return new Response("Not Found", { status: 404 })

--- a/plugin/lib/review-server.ts
+++ b/plugin/lib/review-server.ts
@@ -425,7 +425,7 @@ export async function serveReview(opts: ServeReviewOptions): Promise<{
   const server = Bun.serve({
     port,
     hostname: "127.0.0.1",
-    fetch(req) {
+    async fetch(req) {
       const url = new URL(req.url)
 
       if (req.method === "GET" && (url.pathname === "/" || url.pathname === "/index.html")) {
@@ -469,22 +469,28 @@ export async function serveReview(opts: ServeReviewOptions): Promise<{
       }
 
       if (req.method === "POST" && url.pathname === "/api/feedback") {
-        return req.json().then((body: unknown) => {
-          try {
-            if (typeof body !== "object" || body === null || !("reviews" in body)) {
-              throw new Error("Expected JSON object with 'reviews' key")
-            }
-            writeFileSync(feedbackPath, JSON.stringify(body, null, 2) + "\n")
-            return new Response(JSON.stringify({ ok: true }), {
-              headers: { "Content-Type": "application/json" },
-            })
-          } catch (e) {
-            return new Response(JSON.stringify({ error: String(e) }), {
-              status: 500,
-              headers: { "Content-Type": "application/json" },
-            })
+        try {
+          const body = (await req.json()) as unknown
+          if (typeof body !== "object" || body === null || !("reviews" in body)) {
+            return new Response(
+              JSON.stringify({ error: "Expected JSON object with 'reviews' key" }),
+              {
+                status: 400,
+                headers: { "Content-Type": "application/json" },
+              },
+            )
           }
-        })
+
+          writeFileSync(feedbackPath, JSON.stringify(body, null, 2) + "\n")
+          return new Response(JSON.stringify({ ok: true }), {
+            headers: { "Content-Type": "application/json" },
+          })
+        } catch (e) {
+          return new Response(JSON.stringify({ error: String(e) }), {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+          })
+        }
       }
 
       return new Response("Not Found", { status: 404 })

--- a/plugin/lib/review-server.ts
+++ b/plugin/lib/review-server.ts
@@ -66,6 +66,17 @@ interface Run {
   grading: Record<string, unknown> | null
 }
 
+interface FeedbackReviewItem {
+  run_id: string
+  feedback: string
+  timestamp?: string
+}
+
+interface FeedbackPayload {
+  reviews: FeedbackReviewItem[]
+  status?: string
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -254,6 +265,36 @@ function buildRun(root: string, runDir: string): Run | null {
   }
 
   return { id: runId, prompt, eval_id: evalId, outputs: outputFiles, grading }
+}
+
+function isValidFeedbackPayload(value: unknown): value is FeedbackPayload {
+  if (typeof value !== "object" || value === null) return false
+  if (!Object.prototype.hasOwnProperty.call(value, "reviews")) return false
+
+  const record = value as Record<string, unknown>
+  if (!Array.isArray(record.reviews)) return false
+
+  for (const item of record.reviews) {
+    if (typeof item !== "object" || item === null) return false
+    const review = item as Record<string, unknown>
+    if (typeof review.run_id !== "string") return false
+    if (typeof review.feedback !== "string") return false
+    if (
+      Object.prototype.hasOwnProperty.call(review, "timestamp") &&
+      typeof review.timestamp !== "string"
+    ) {
+      return false
+    }
+  }
+
+  if (
+    Object.prototype.hasOwnProperty.call(record, "status") &&
+    typeof record.status !== "string"
+  ) {
+    return false
+  }
+
+  return true
 }
 
 // ---------------------------------------------------------------------------
@@ -479,9 +520,9 @@ export async function serveReview(opts: ServeReviewOptions): Promise<{
           })
         }
 
-        if (typeof body !== "object" || body === null || !("reviews" in body)) {
+        if (!isValidFeedbackPayload(body)) {
           return new Response(
-            JSON.stringify({ error: "Expected JSON object with 'reviews' key" }),
+            JSON.stringify({ error: "Expected JSON object with a valid 'reviews' array" }),
             {
               status: 400,
               headers: { "Content-Type": "application/json" },

--- a/plugin/skill/SKILL.md
+++ b/plugin/skill/SKILL.md
@@ -72,6 +72,8 @@ Check available MCPs — if useful for research (searching docs, finding similar
 
 ### Write the SKILL.md
 
+For new skills, default to a staging location instead of the current repo/worktree. Use a temp workspace like `/tmp/opencode-skills/<skill-name>/` unless the user explicitly requests another path. This avoids cluttering unrelated repositories during skill development.
+
 Based on the user interview, fill in these components:
 
 - **name**: Skill identifier (kebab-case, 1–64 chars, regex `^[a-z0-9]+(-[a-z0-9]+)*$`)
@@ -177,7 +179,7 @@ See `references/schemas.md` for the full schema (including the `assertions` fiel
 
 This section is one continuous sequence — don't stop partway through. Do NOT use `/skill-test` or any other testing skill.
 
-Put results in `<skill-name>-workspace/` as a sibling to the skill directory. Within the workspace, organize results by iteration (`iteration-1/`, `iteration-2/`, etc.) and within that, each test case gets a directory (`eval-0/`, `eval-1/`, etc.). Don't create all of this upfront — just create directories as you go.
+Put results in `<skill-name>-workspace/` next to the staged skill directory (for example `/tmp/opencode-skills/<skill-name>-workspace/`). Within the workspace, organize results by iteration (`iteration-1/`, `iteration-2/`, etc.) and within that, each test case gets a directory (`eval-0/`, `eval-1/`, etc.). Don't create all of this upfront — just create directories as you go.
 
 ### Step 1: Spawn all runs (with-skill AND baseline) in the same turn
 
@@ -426,6 +428,8 @@ After the skill is created and validated, help the user install it. Skills can b
 - **Global**: `~/.config/opencode/skills/<skill-name>/SKILL.md` — available in all projects
 
 Copy the skill directory to the desired location. The directory name must match the `name` field in the SKILL.md frontmatter.
+
+Keep all draft/eval artifacts in the staging location; only copy the final validated skill directory into project/global install paths.
 
 You can validate the skill before installation by calling the `skill_validate` tool.
 

--- a/plugin/skill/SKILL.md
+++ b/plugin/skill/SKILL.md
@@ -72,7 +72,7 @@ Check available MCPs — if useful for research (searching docs, finding similar
 
 ### Write the SKILL.md
 
-For new skills, default to a staging location instead of the current repo/worktree. Use a temp workspace like `/tmp/opencode-skills/<skill-name>/` unless the user explicitly requests another path. This avoids cluttering unrelated repositories during skill development.
+For new skills, default to a staging location instead of the current repo/worktree. Use the system temp directory unless the user explicitly requests another path (for example: Unix/macOS `/tmp/opencode-skills/<skill-name>/`, `$TMPDIR/opencode-skills/<skill-name>/`; Windows `%TEMP%\\opencode-skills\\<skill-name>\\`). This avoids cluttering unrelated repositories during skill development.
 
 Based on the user interview, fill in these components:
 
@@ -179,7 +179,7 @@ See `references/schemas.md` for the full schema (including the `assertions` fiel
 
 This section is one continuous sequence — don't stop partway through. Do NOT use `/skill-test` or any other testing skill.
 
-Put results in `<skill-name>-workspace/` next to the staged skill directory (for example `/tmp/opencode-skills/<skill-name>-workspace/`). Within the workspace, organize results by iteration (`iteration-1/`, `iteration-2/`, etc.) and within that, each test case gets a directory (`eval-0/`, `eval-1/`, etc.). Don't create all of this upfront — just create directories as you go.
+Put results in `<skill-name>-workspace/` next to the staged skill directory in the system temp area (for example: Unix/macOS `/tmp/opencode-skills/<skill-name>-workspace/`; Windows `%TEMP%\\opencode-skills\\<skill-name>-workspace\\`). Within the workspace, organize results by iteration (`iteration-1/`, `iteration-2/`, etc.) and within that, each test case gets a directory (`eval-0/`, `eval-1/`, etc.). Don't create all of this upfront — just create directories as you go.
 
 ### Step 1: Spawn all runs (with-skill AND baseline) in the same turn
 

--- a/skill-creator/SKILL.md
+++ b/skill-creator/SKILL.md
@@ -72,6 +72,8 @@ Check available MCPs — if useful for research (searching docs, finding similar
 
 ### Write the SKILL.md
 
+For new skills, default to a staging location instead of the current repo/worktree. Use a temp workspace like `/tmp/opencode-skills/<skill-name>/` unless the user explicitly requests another path. This avoids cluttering unrelated repositories during skill development.
+
 Based on the user interview, fill in these components:
 
 - **name**: Skill identifier (kebab-case, 1–64 chars, regex `^[a-z0-9]+(-[a-z0-9]+)*$`)
@@ -177,7 +179,7 @@ See `references/schemas.md` for the full schema (including the `assertions` fiel
 
 This section is one continuous sequence — don't stop partway through. Do NOT use `/skill-test` or any other testing skill.
 
-Put results in `<skill-name>-workspace/` as a sibling to the skill directory. Within the workspace, organize results by iteration (`iteration-1/`, `iteration-2/`, etc.) and within that, each test case gets a directory (`eval-0/`, `eval-1/`, etc.). Don't create all of this upfront — just create directories as you go.
+Put results in `<skill-name>-workspace/` next to the staged skill directory (for example `/tmp/opencode-skills/<skill-name>-workspace/`). Within the workspace, organize results by iteration (`iteration-1/`, `iteration-2/`, etc.) and within that, each test case gets a directory (`eval-0/`, `eval-1/`, etc.). Don't create all of this upfront — just create directories as you go.
 
 ### Step 1: Spawn all runs (with-skill AND baseline) in the same turn
 
@@ -426,6 +428,8 @@ After the skill is created and validated, help the user install it. Skills can b
 - **Global**: `~/.config/opencode/skills/<skill-name>/SKILL.md` — available in all projects
 
 Copy the skill directory to the desired location. The directory name must match the `name` field in the SKILL.md frontmatter.
+
+Keep all draft/eval artifacts in the staging location; only copy the final validated skill directory into project/global install paths.
 
 You can validate the skill before installation by calling the `skill_validate` tool.
 

--- a/skill-creator/SKILL.md
+++ b/skill-creator/SKILL.md
@@ -72,7 +72,7 @@ Check available MCPs — if useful for research (searching docs, finding similar
 
 ### Write the SKILL.md
 
-For new skills, default to a staging location instead of the current repo/worktree. Use a temp workspace like `/tmp/opencode-skills/<skill-name>/` unless the user explicitly requests another path. This avoids cluttering unrelated repositories during skill development.
+For new skills, default to a staging location instead of the current repo/worktree. Use the system temp directory unless the user explicitly requests another path (for example: Unix/macOS `/tmp/opencode-skills/<skill-name>/`, `$TMPDIR/opencode-skills/<skill-name>/`; Windows `%TEMP%\\opencode-skills\\<skill-name>\\`). This avoids cluttering unrelated repositories during skill development.
 
 Based on the user interview, fill in these components:
 
@@ -179,7 +179,7 @@ See `references/schemas.md` for the full schema (including the `assertions` fiel
 
 This section is one continuous sequence — don't stop partway through. Do NOT use `/skill-test` or any other testing skill.
 
-Put results in `<skill-name>-workspace/` next to the staged skill directory (for example `/tmp/opencode-skills/<skill-name>-workspace/`). Within the workspace, organize results by iteration (`iteration-1/`, `iteration-2/`, etc.) and within that, each test case gets a directory (`eval-0/`, `eval-1/`, etc.). Don't create all of this upfront — just create directories as you go.
+Put results in `<skill-name>-workspace/` next to the staged skill directory in the system temp area (for example: Unix/macOS `/tmp/opencode-skills/<skill-name>-workspace/`; Windows `%TEMP%\\opencode-skills\\<skill-name>-workspace\\`). Within the workspace, organize results by iteration (`iteration-1/`, `iteration-2/`, etc.) and within that, each test case gets a directory (`eval-0/`, `eval-1/`, etc.). Don't create all of this upfront — just create directories as you go.
 
 ### Step 1: Spawn all runs (with-skill AND baseline) in the same turn
 


### PR DESCRIPTION
## Summary
- Fix `skill_serve_review` feedback POST handling so the Bun server always returns a JSON `Response` (including malformed payloads), avoiding Bun internal error pages when `req.json()` fails.
- Fix `skill_improve_description` CLI invocation by inserting `--` after `--file <tmpPath>`, ensuring the trailing prompt is parsed as the message (not another file path).
- Add guidance and defaults for staging skill drafts/eval artifacts under `/tmp/opencode-skills/...` and keeping final install targets only in `.opencode/skills/<skill-name>/` or `~/.config/opencode/skills/<skill-name>/`.
- Add `.gitignore` entries for generated skill-creator artifacts (workspace outputs, benchmark files, feedback files, optimizer logs, temp exports).

## Why
The runtime fixes address failures observed in real usage: review viewer server crashes and optimizer runs failing with `File not found: Process the attached file...`. The staging + ignore updates prevent plugin repo clutter during iterative skill testing while preserving the full Claude-style eval loop.

## Validation
- `bun -e "import('./plugin/lib/review-server.ts').then(() => console.log('review-server ok'))"`
- `bun -e "import('./plugin/lib/improve-description.ts').then(() => console.log('improve-description ok'))"`
- `diff -rq skill-creator plugin/skill` (no differences)