### PR TITLE
feat: add universal code reviewer workflow

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,32 @@
+name: Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && (
+        startsWith(github.event.comment.body, '/review') ||
+        startsWith(github.event.comment.body, '/summary') ||
+        startsWith(github.event.comment.body, '/help')
+      ))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Universal Code Review
+        uses: antongulin/universal-code-reviewer@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          llm-api-key: ${{ secrets.LLM_API_KEY }}
+          llm-base-url: ${{ secrets.LLM_BASE_URL }}
+          model: ${{ secrets.LLM_MODEL }}
+          fail-on-critical: "false"


### PR DESCRIPTION
## Summary

Closes #6

Adds automated AI-powered code reviews on every pull request using [universal-code-reviewer](https://github.com/antongulin/universal-code-reviewer).

## What changed

- New `.github/workflows/code-review.yml` workflow
- Triggers on PR open, synchronize, reopen
- Supports manual slash commands: `/review`, `/summary`, `/help`
- Uses `antongulin/universal-code-reviewer@main`
- LLM credentials from existing repository secrets (`LLM_API_KEY`, `LLM_BASE_URL`, `LLM_MODEL`)

## No existing files modified

Only new workflow file added — zero risk to existing functionality.