### PR TITLE
fix(installer): support JSONC config files (opencode.jsonc) with jsonc-parser

### DIFF
--- a/plugin/bin/opencode-skill-creator.js
+++ b/plugin/bin/opencode-skill-creator.js
@@ -3,6 +3,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs"
 import { homedir } from "os"
 import { join, dirname } from "path"
+import { parse, modify, applyEdits } from "jsonc-parser"
 
 const PKG_PATH = new URL("../package.json", import.meta.url)
 
@@ -100,9 +101,14 @@ function parseArgs(argv) {
 
 function getConfigPath(globalInstall) {
   if (globalInstall) {
-    return join(homedir(), ".config", "opencode", "opencode.json")
+    const configDir = join(homedir(), ".config", "opencode")
+    return existsSync(join(configDir, "opencode.jsonc"))
+      ? join(configDir, "opencode.jsonc")
+      : join(configDir, "opencode.json")
   }
-  return join(process.cwd(), "opencode.json")
+  return existsSync(join(process.cwd(), "opencode.jsonc"))
+    ? join(process.cwd(), "opencode.jsonc")
+    : join(process.cwd(), "opencode.json")
 }
 
 function loadConfig(path) {
@@ -110,21 +116,30 @@ function loadConfig(path) {
     return {}
   }
 
-  const raw = readFileSync(path, "utf-8").trim()
-  if (!raw) return {}
+  const raw = readFileSync(path, "utf-8")
+  if (!raw.trim()) return {}
 
   try {
-    return JSON.parse(raw)
+    return parse(raw)
   } catch {
     throw new Error(
-      `Could not parse JSON in ${path}. Please fix the file, then re-run this installer.`
+      `Could not parse JSONC in ${path}. Please fix the file, then re-run this installer.`
     )
   }
 }
 
 function saveConfig(path, config) {
   mkdirSync(dirname(path), { recursive: true })
-  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`, "utf-8")
+
+  let raw
+  if (existsSync(path)) {
+    raw = readFileSync(path, "utf-8")
+  } else {
+    raw = "{}"
+  }
+
+  const edits = modify(raw, ["plugin"], config.plugin, {})
+  writeFileSync(path, applyEdits(raw, edits), "utf-8")
 }
 
 function ensurePlugin(config) {

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -52,5 +52,8 @@
   "devDependencies": {
     "@opencode-ai/plugin": "^1.0.0",
     "@types/bun": "latest"
+  },
+  "dependencies": {
+    "jsonc-parser": "^3.3.1"
   }
 }


### PR DESCRIPTION
## Problem
As the issue #13, try fix it by my opencode.

The `npx opencode-skill-creator install` command crashes when the user has an `opencode.jsonc` config file, because the installer uses `JSON.parse()` which throws on comments and trailing commas.
Additionally, the installer only looked for `opencode.json`, ignoring the `.jsonc` variant that OpenCode itself prefers.
## Solution
1. **Prefer `.jsonc` over `.json`** in `getConfigPath()` — this matches OpenCode's own resolution order (JSONC overrides JSON).
2. **Parse with `jsonc-parser`** instead of `JSON.parse()` — supports comments, trailing commas, and other JSONC syntax.
3. **Write with `modify()` + `applyEdits()`** instead of `JSON.stringify()` — mutates only the `plugin` field, leaving user comments and other formatting intact.
## Files changed
| File | Change |
|------|--------|
| `plugin/bin/opencode-skill-creator.js` | `getConfigPath` now checks `.jsonc` first; `loadConfig` uses `jsonc-parser.parse`; `saveConfig` uses `jsonc-parser.modify` / `applyEdits` |
| `plugin/package.json` | Added `jsonc-parser` to `dependencies` |
## Known limitation
`jsonc-parser`'s `modify()` without explicit `formattingOptions` emits compact single-line arrays.
If a user's config has:
```jsonc
"plugin": [
  "existing-plugin"
]
It may become:
"plugin": ["existing-plugin","opencode-skill-creator"]
Comments inside the array are preserved; the file remains valid JSONC. This is a cosmetic issue.
Why jsonc-parser over comment-json?
- OpenCode / VS Code already depend on it (ecosystem alignment)
- No CommentArray concept — users can't accidentally wipe comments by assigning a plain array
- The formatting gap is fixable by passing formattingOptions to modify() in a future PR
Testing
- ✅ Local install on real ~/.config/opencode/opencode.jsonc (with comments) — plugin appended successfully, comments preserved
- ✅ Verified fallback to opencode.json when .jsonc does not exist
- ✅ Node.js v26
Fixes: installer was unusable for anyone with .jsonc config files.