### PR TITLE
Fix installer cleanup for stale plugin faults

### DIFF
--- a/plugin/bin/opencode-skill-creator.js
+++ b/plugin/bin/opencode-skill-creator.js
@@ -115,7 +115,7 @@ function getConfigPath(globalInstall) {
 
 function clearStaleOpenCodePackageCache() {
   const currentVersion = getVersion()
-  if (currentVersion === "unknown") return false
+  if (currentVersion === "unknown") return { cleared: false, error: null }
 
   const cacheDir = process.env.XDG_CACHE_HOME || join(homedir(), ".cache")
   const packageCacheRoot = join(
@@ -131,17 +131,23 @@ function clearStaleOpenCodePackageCache() {
     "package.json"
   )
 
-  if (!existsSync(cachedPackageJson)) return false
+  if (!existsSync(cachedPackageJson)) return { cleared: false, error: null }
 
   try {
     const cachedPackage = JSON.parse(readFileSync(cachedPackageJson, "utf-8"))
-    if (cachedPackage.version === currentVersion) return false
+    if (cachedPackage.version === currentVersion) {
+      return { cleared: false, error: null }
+    }
   } catch {
     // Broken cache entries should be removed so OpenCode can recreate them.
   }
 
-  rmSync(packageCacheRoot, { recursive: true, force: true })
-  return true
+  try {
+    rmSync(packageCacheRoot, { recursive: true, force: true })
+    return { cleared: true, error: null }
+  } catch (error) {
+    return { cleared: false, error }
+  }
 }
 
 function getDesktopGlobalDataPath() {
@@ -292,8 +298,15 @@ function main() {
     console.log('"opencode-skill-creator" is already in the "plugin" array.')
   }
 
-  if (global && clearStaleOpenCodePackageCache()) {
-    console.log("Cleared stale OpenCode package cache for opencode-skill-creator.")
+  if (global) {
+    const cacheCleanup = clearStaleOpenCodePackageCache()
+    if (cacheCleanup.cleared) {
+      console.log("Cleared stale OpenCode package cache for opencode-skill-creator.")
+    } else if (cacheCleanup.error) {
+      console.warn(
+        `Could not clear stale OpenCode package cache: ${cacheCleanup.error.message}`
+      )
+    }
   }
 
   if (global) {

--- a/plugin/bin/opencode-skill-creator.js
+++ b/plugin/bin/opencode-skill-creator.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs"
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs"
 import { applyEdits, modify, parse, printParseErrorCode } from "jsonc-parser"
 import { homedir } from "os"
 import { join, dirname } from "path"
 
 const PKG_PATH = new URL("../package.json", import.meta.url)
+const PLUGIN_LOAD_ERROR_PREFIX = "Failed to load plugin opencode-skill-creator:"
 
 function getVersion() {
   try {
@@ -112,6 +113,88 @@ function getConfigPath(globalInstall) {
   return join(configDir, "opencode.json")
 }
 
+function clearStaleOpenCodePackageCache() {
+  const currentVersion = getVersion()
+  if (currentVersion === "unknown") return false
+
+  const cacheDir = process.env.XDG_CACHE_HOME || join(homedir(), ".cache")
+  const packageCacheRoot = join(
+    cacheDir,
+    "opencode",
+    "packages",
+    "opencode-skill-creator@latest"
+  )
+  const cachedPackageJson = join(
+    packageCacheRoot,
+    "node_modules",
+    "opencode-skill-creator",
+    "package.json"
+  )
+
+  if (!existsSync(cachedPackageJson)) return false
+
+  try {
+    const cachedPackage = JSON.parse(readFileSync(cachedPackageJson, "utf-8"))
+    if (cachedPackage.version === currentVersion) return false
+  } catch {
+    // Broken cache entries should be removed so OpenCode can recreate them.
+  }
+
+  rmSync(packageCacheRoot, { recursive: true, force: true })
+  return true
+}
+
+function getDesktopGlobalDataPath() {
+  if (process.platform === "darwin") {
+    return join(
+      homedir(),
+      "Library",
+      "Application Support",
+      "ai.opencode.desktop",
+      "opencode.global.dat"
+    )
+  }
+
+  if (process.platform === "win32") {
+    const appData = process.env.APPDATA || join(homedir(), "AppData", "Roaming")
+    return join(appData, "ai.opencode.desktop", "opencode.global.dat")
+  }
+
+  const configDir = process.env.XDG_CONFIG_HOME || join(homedir(), ".config")
+  return join(configDir, "ai.opencode.desktop", "opencode.global.dat")
+}
+
+function clearPluginFaultNotifications() {
+  const dataPath = getDesktopGlobalDataPath()
+  if (!existsSync(dataPath)) return 0
+
+  try {
+    const data = JSON.parse(readFileSync(dataPath, "utf-8"))
+    if (typeof data.notification !== "string") return 0
+
+    const notifications = JSON.parse(data.notification)
+    if (!Array.isArray(notifications.list)) return 0
+
+    const originalCount = notifications.list.length
+    notifications.list = notifications.list.filter((notification) => {
+      if (notification?.type !== "error") return true
+
+      const message = notification?.error?.data?.message
+      return typeof message !== "string" || !message.startsWith(PLUGIN_LOAD_ERROR_PREFIX)
+    })
+
+    const removedCount = originalCount - notifications.list.length
+    if (removedCount === 0) return 0
+
+    data.notification = JSON.stringify(notifications)
+    writeFileSync(dataPath, `${JSON.stringify(data, null, "\t")}\n`, "utf-8")
+    return removedCount
+  } catch {
+    // Desktop state cleanup is best-effort; installation should not fail here.
+    return 0
+  }
+}
+
 function loadConfig(path) {
   if (!existsSync(path)) {
     return {
@@ -207,6 +290,20 @@ function main() {
   } else {
     console.log(`No changes needed for ${configPath}`)
     console.log('"opencode-skill-creator" is already in the "plugin" array.')
+  }
+
+  if (global && clearStaleOpenCodePackageCache()) {
+    console.log("Cleared stale OpenCode package cache for opencode-skill-creator.")
+  }
+
+  if (global) {
+    const removedNotifications = clearPluginFaultNotifications()
+    if (removedNotifications > 0) {
+      const noun = removedNotifications === 1 ? "notification" : "notifications"
+      console.log(
+        `Removed ${removedNotifications} stale opencode-skill-creator plugin fault ${noun}.`
+      )
+    }
   }
 
   console.log("\nNext steps:")

--- a/plugin/test/installer.test.mjs
+++ b/plugin/test/installer.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict"
 import { execFile } from "node:child_process"
 import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
-import { mkdir, rm } from "node:fs/promises"
+import { chmod, mkdir, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -233,6 +233,38 @@ test("global install clears stale OpenCode package cache", async () => {
 
     assert.equal(existsSync(packagePath), false)
     assert.match(result.stdout, /Cleared stale OpenCode package cache/)
+  })
+})
+
+test("global install continues when stale cache cleanup fails", async () => {
+  await withHome(async (home) => {
+    const path = configPath(home, "opencode.json")
+    writeFileSync(path, `{
+  "plugin": []
+}
+`, "utf-8")
+
+    const packagePath = cachedPackagePath(home)
+    await mkdir(packagePath, { recursive: true })
+    writeFileSync(join(packagePath, "package.json"), `{
+  "name": "opencode-skill-creator",
+  "version": "0.2.11",
+  "main": "./skill-creator.ts"
+}
+`, "utf-8")
+
+    writeFileSync(join(packagePath, "open-file"), "keep", "utf-8")
+
+    const packagesDir = join(packagePath, "..", "..", "..")
+    await chmod(packagesDir, 0o555)
+    try {
+      await assert.doesNotReject(runInstaller(home))
+    } finally {
+      await chmod(packagesDir, 0o755)
+    }
+
+    const updated = readFileSync(path, "utf-8")
+    assert.match(updated, /"opencode-skill-creator"/)
   })
 })
 

--- a/plugin/test/installer.test.mjs
+++ b/plugin/test/installer.test.mjs
@@ -19,7 +19,13 @@ async function createHome() {
 
 async function runInstaller(home) {
   return execFileAsync(process.execPath, [binPath, "install", "--global"], {
-    env: { ...process.env, HOME: home },
+    env: {
+      ...process.env,
+      APPDATA: join(home, "AppData", "Roaming"),
+      HOME: home,
+      XDG_CACHE_HOME: join(home, ".cache"),
+      XDG_CONFIG_HOME: join(home, ".config"),
+    },
   })
 }
 
@@ -32,6 +38,52 @@ async function runProjectInstaller(cwd) {
 
 function configPath(home, filename) {
   return join(home, ".config", "opencode", filename)
+}
+
+function cachedPackagePath(home) {
+  return join(
+    home,
+    ".cache",
+    "opencode",
+    "packages",
+    "opencode-skill-creator@latest",
+    "node_modules",
+    "opencode-skill-creator"
+  )
+}
+
+function desktopDataPath(home) {
+  if (process.platform === "darwin") {
+    return join(home, "Library", "Application Support", "ai.opencode.desktop", "opencode.global.dat")
+  }
+
+  if (process.platform === "win32") {
+    return join(home, "AppData", "Roaming", "ai.opencode.desktop", "opencode.global.dat")
+  }
+
+  return join(home, ".config", "ai.opencode.desktop", "opencode.global.dat")
+}
+
+async function writeDesktopNotifications(home, notifications) {
+  const path = desktopDataPath(home)
+  await mkdir(join(path, ".."), { recursive: true })
+  writeFileSync(
+    path,
+    `${JSON.stringify(
+      {
+        notification: JSON.stringify({ list: notifications }),
+        layout: JSON.stringify({ sidebar: { opened: true } }),
+      },
+      null,
+      "\t"
+    )}\n`,
+    "utf-8"
+  )
+}
+
+function readDesktopNotifications(home) {
+  const data = JSON.parse(readFileSync(desktopDataPath(home), "utf-8"))
+  return JSON.parse(data.notification).list
 }
 
 async function withHome(fn) {
@@ -157,6 +209,110 @@ test("global install rejects invalid JSONC without modifying the file", async ()
     await assert.rejects(runInstaller(home), /Could not parse JSONC/)
     assert.equal(readFileSync(path, "utf-8"), original)
     assert.equal(existsSync(configPath(home, "opencode.json")), false)
+  })
+})
+
+test("global install clears stale OpenCode package cache", async () => {
+  await withHome(async (home) => {
+    const path = configPath(home, "opencode.json")
+    writeFileSync(path, `{
+  "plugin": ["opencode-skill-creator"]
+}
+`, "utf-8")
+
+    const packagePath = cachedPackagePath(home)
+    await mkdir(packagePath, { recursive: true })
+    writeFileSync(join(packagePath, "package.json"), `{
+  "name": "opencode-skill-creator",
+  "version": "0.2.11",
+  "main": "./skill-creator.ts"
+}
+`, "utf-8")
+
+    const result = await runInstaller(home)
+
+    assert.equal(existsSync(packagePath), false)
+    assert.match(result.stdout, /Cleared stale OpenCode package cache/)
+  })
+})
+
+test("global install removes opencode-skill-creator plugin fault notifications", async () => {
+  await withHome(async (home) => {
+    const path = configPath(home, "opencode.json")
+    writeFileSync(path, `{
+  "plugin": ["opencode-skill-creator"]
+}
+`, "utf-8")
+
+    await writeDesktopNotifications(home, [
+      {
+        directory: "/tmp/project-a",
+        time: 1,
+        viewed: false,
+        type: "error",
+        session: "global",
+        error: {
+          name: "UnknownError",
+          data: {
+            message:
+              "Failed to load plugin opencode-skill-creator: Stripping types is currently unsupported for files under node_modules",
+          },
+        },
+      },
+      {
+        directory: "/tmp/project-b",
+        time: 2,
+        viewed: false,
+        type: "error",
+        session: "global",
+        error: {
+          name: "UnknownError",
+          data: { message: "Failed to load plugin other-plugin: boom" },
+        },
+      },
+      {
+        directory: "/tmp/project-c",
+        time: 3,
+        viewed: false,
+        type: "error",
+        session: "global",
+        error: {
+          name: "UnknownError",
+          data: { message: "Failed to load plugin opencode-skill-creator-extra: boom" },
+        },
+      },
+      {
+        directory: "/tmp/project-d",
+        time: 4,
+        viewed: false,
+        type: "turn-complete",
+        session: "ses_test",
+      },
+    ])
+
+    const result = await runInstaller(home)
+
+    const notifications = readDesktopNotifications(home)
+    assert.equal(notifications.length, 3)
+    assert.equal(
+      notifications.some((notification) =>
+        JSON.stringify(notification).includes("Failed to load plugin opencode-skill-creator:")
+      ),
+      false
+    )
+    assert.equal(
+      notifications.some((notification) =>
+        JSON.stringify(notification).includes("Failed to load plugin other-plugin")
+      ),
+      true
+    )
+    assert.equal(
+      notifications.some((notification) =>
+        JSON.stringify(notification).includes("Failed to load plugin opencode-skill-creator-extra")
+      ),
+      true
+    )
+    assert.match(result.stdout, /Removed 1 stale opencode-skill-creator plugin fault notification/)
   })
 })
 


### PR DESCRIPTION
## Summary
- Clear stale OpenCode package cache for opencode-skill-creator when installer version differs from cached package version.
- Remove stale OpenCode Desktop notifications caused by opencode-skill-creator plugin load failures.
- Preserve unrelated notifications and unrelated plugin errors.

## Test Plan
- npm test
- npm run test:ts

## Notes
- Notification cleanup is best-effort and only runs for global installs.
- The filter only removes error notifications whose message starts with `Failed to load plugin opencode-skill-creator:`.