### PR TITLE
Fix OpenCode plugin loader export crash

### DIFF
--- a/plugin/dist/build-manifest.json
+++ b/plugin/dist/build-manifest.json
@@ -1,5 +1,6 @@
 {
   "entrypoint": "skill-creator.ts",
-  "sourceHash": "97c979640712f27192e96cee93d114bb0a855ef89d15a8477819b417d6b94164",
-  "builtAt": "2026-05-17T01:15:10.365Z"
+  "runtimeEntrypoint": "runtime-entry.ts",
+  "sourceHash": "e9e1cd06280b59760da940adbf0eb6940a76feebb0201512919405c5d17b26a3",
+  "builtAt": "2026-05-19T16:13:48.532Z"
 }

--- a/plugin/dist/build-manifest.json
+++ b/plugin/dist/build-manifest.json
@@ -1,6 +1,6 @@
 {
   "entrypoint": "skill-creator.ts",
   "runtimeEntrypoint": "runtime-entry.ts",
-  "sourceHash": "e9e1cd06280b59760da940adbf0eb6940a76feebb0201512919405c5d17b26a3",
-  "builtAt": "2026-05-19T16:13:48.532Z"
+  "sourceHash": "fe3ce5066e4462246b3abd27a2882e6fe250f1f16eced5b202b0434eaff6e329",
+  "builtAt": "2026-05-19T16:18:47.130Z"
 }

--- a/plugin/dist/package.json
+++ b/plugin/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-skill-creator",
-  "version": "0.2.13",
+  "version": "0.2.15",
   "description": "OpenCode plugin for skill creation — custom tools for validation, evaluation, description optimization, benchmarking, and review serving.",
   "type": "module",
   "main": "./dist/skill-creator.js",

--- a/plugin/dist/skill-creator.js
+++ b/plugin/dist/skill-creator.js
@@ -15133,12 +15133,9 @@ var SkillCreatorPlugin = async (ctx) => {
   };
 };
 var skill_creator_default = SkillCreatorPlugin;
+
+// runtime-entry.ts
+var runtime_entry_default = skill_creator_default;
 export {
-  maybeAutoRefreshPluginCache,
-  isInsidePath,
-  getAutoUpdatePaths,
-  skill_creator_default as default,
-  SkillCreatorPlugin,
-  AUTO_UPDATE_TTL_MS,
-  AUTO_UPDATE_STATUS_FILE
+  runtime_entry_default as default
 };

--- a/plugin/runtime-entry.ts
+++ b/plugin/runtime-entry.ts
@@ -1,0 +1,3 @@
+import SkillCreatorPlugin from "./skill-creator"
+
+export default SkillCreatorPlugin

--- a/plugin/runtime-entry.ts
+++ b/plugin/runtime-entry.ts
@@ -1,3 +1,5 @@
 import SkillCreatorPlugin from "./skill-creator"
 
+// Runtime-only wrapper: keep the published OpenCode entrypoint to a single
+// default export while skill-creator.ts keeps named exports for tests.
 export default SkillCreatorPlugin

--- a/plugin/scripts/build.mjs
+++ b/plugin/scripts/build.mjs
@@ -13,6 +13,7 @@ import { fileURLToPath } from "node:url"
 
 const pluginRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
 const distRoot = resolve(pluginRoot, "dist")
+const runtimeEntry = "runtime-entry.ts"
 
 function listSourceFiles(dir) {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
@@ -24,6 +25,7 @@ function listSourceFiles(dir) {
 
 function hashPluginSources() {
   const files = [
+    resolve(pluginRoot, runtimeEntry),
     resolve(pluginRoot, "skill-creator.ts"),
     ...listSourceFiles(resolve(pluginRoot, "lib")),
   ].sort()
@@ -49,7 +51,7 @@ execFileSync(
   "bun",
   [
     "build",
-    "./skill-creator.ts",
+    `./${runtimeEntry}`,
     "--target=bun",
     "--format=esm",
     "--outfile=dist/skill-creator.js",
@@ -68,6 +70,7 @@ writeFileSync(
   `${JSON.stringify(
     {
       entrypoint: "skill-creator.ts",
+      runtimeEntrypoint: runtimeEntry,
       sourceHash: hashPluginSources(),
       builtAt: new Date().toISOString(),
     },

--- a/plugin/test/package.test.mjs
+++ b/plugin/test/package.test.mjs
@@ -16,6 +16,7 @@ import { fileURLToPath } from "node:url"
 import test from "node:test"
 
 const pluginSourcePath = fileURLToPath(new URL("../skill-creator.ts", import.meta.url))
+const runtimeEntryPath = fileURLToPath(new URL("../runtime-entry.ts", import.meta.url))
 const packageJsonPath = fileURLToPath(new URL("../package.json", import.meta.url))
 const pluginRoot = fileURLToPath(new URL("..", import.meta.url))
 const distEntryPath = fileURLToPath(new URL("../dist/skill-creator.js", import.meta.url))
@@ -37,7 +38,7 @@ function listSourceFiles(dir) {
 }
 
 function hashPluginSources() {
-  const files = [pluginSourcePath, ...listSourceFiles(join(pluginRoot, "lib"))].sort()
+  const files = [runtimeEntryPath, pluginSourcePath, ...listSourceFiles(join(pluginRoot, "lib"))].sort()
   const hash = createHash("sha256")
   for (const file of files) {
     hash.update(relative(pluginRoot, file))
@@ -86,6 +87,13 @@ test("bundled skill uses the opencode-specific skill name", () => {
 test("compiled entrypoint imports as a plugin function", async () => {
   const mod = await import(distEntryPath)
 
+  assert.equal(typeof mod.default, "function")
+})
+
+test("compiled entrypoint only exposes plugin functions for legacy OpenCode loaders", async () => {
+  const mod = await import(`${distEntryPath}?legacy-loader=${Date.now()}`)
+
+  assert.deepEqual(Object.keys(mod), ["default"])
   assert.equal(typeof mod.default, "function")
 })
 
@@ -159,6 +167,7 @@ test("compiled artifact manifest matches current TypeScript sources", () => {
   const manifest = JSON.parse(readFileSync(buildManifestPath, "utf-8"))
 
   assert.equal(manifest.entrypoint, "skill-creator.ts")
+  assert.equal(manifest.runtimeEntrypoint, "runtime-entry.ts")
   assert.equal(manifest.sourceHash, hashPluginSources())
   assert.equal(typeof manifest.builtAt, "string")
   assert.equal(Number.isNaN(Date.parse(manifest.builtAt)), false)

--- a/plugin/test/package.test.mjs
+++ b/plugin/test/package.test.mjs
@@ -91,7 +91,7 @@ test("compiled entrypoint imports as a plugin function", async () => {
 })
 
 test("compiled entrypoint only exposes plugin functions for legacy OpenCode loaders", async () => {
-  const mod = await import(`${distEntryPath}?legacy-loader=${Date.now()}`)
+  const mod = await import(`${distEntryPath}?legacy-loader`)
 
   assert.deepEqual(Object.keys(mod), ["default"])
   assert.equal(typeof mod.default, "function")

--- a/plugin/test/package.test.mjs
+++ b/plugin/test/package.test.mjs
@@ -91,7 +91,7 @@ test("compiled entrypoint imports as a plugin function", async () => {
 })
 
 test("compiled entrypoint only exposes plugin functions for legacy OpenCode loaders", async () => {
-  const mod = await import(`${distEntryPath}?legacy-loader`)
+  const mod = await import(distEntryPath)
 
   assert.deepEqual(Object.keys(mod), ["default"])
   assert.equal(typeof mod.default, "function")


### PR DESCRIPTION
## Summary
- Add a tiny runtime entrypoint that exports only the default OpenCode plugin function.
- Build the published `dist/skill-creator.js` from that runtime entrypoint so OpenCode legacy loaders do not try to call named utility exports.
- Add a regression test that the compiled entrypoint exposes only `default`.

Fixes #18.

## Notes
This keeps compatibility broad without adding runtime branching or dependency churn. The current OpenCode plugin docs still use the lightweight `@opencode-ai/plugin` TypeScript plugin shape, and local installs resolve `@opencode-ai/plugin` to the current `1.15.5` release.

## Test Plan
- [x] `npm run build`
- [x] `npm test`
- [x] `npm run test:ts`
- [x] Bun loader simulation imports `dist/skill-creator.js`, iterates module exports, and initializes the single default plugin export.
- [x] `git diff --check`
- [x] `npm pack --dry-run --json`