### PR TITLE
ci: use npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,7 +82,7 @@ jobs:
           fi
 
       - name: Publish to npm
-        if: steps.npm.outputs.exists != 'true'
+        if: steps.npm.outputs.exists != 'true' && github.repository == 'antongulin/opencode-skill-creator' && github.ref == 'refs/heads/main'
         run: npm publish --access public --provenance
         working-directory: plugin
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,6 +82,8 @@ jobs:
           fi
 
       - name: Publish to npm
+        # npm trusted publishing is bound to this repository/workflow on npmjs.com.
+        # Keep the guard explicit so forks and non-main refs cannot publish.
         if: steps.npm.outputs.exists != 'true' && github.repository == 'antongulin/opencode-skill-creator' && github.ref == 'refs/heads/main'
         run: npm publish --access public --provenance
         working-directory: plugin

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -82,10 +83,8 @@ jobs:
 
       - name: Publish to npm
         if: steps.npm.outputs.exists != 'true'
-        run: npm publish --access public
+        run: npm publish --access public --provenance
         working-directory: plugin
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Check GitHub release
         id: release

--- a/plugin/dist/build-manifest.json
+++ b/plugin/dist/build-manifest.json
@@ -2,5 +2,5 @@
   "entrypoint": "skill-creator.ts",
   "runtimeEntrypoint": "runtime-entry.ts",
   "sourceHash": "1bc2a2e2b02cfbbff2c6100d940b5c56bbcd9bd3e923c7d30e080b3b509ef164",
-  "builtAt": "2026-05-25T04:14:58.551Z"
+  "builtAt": "2026-05-25T04:18:44.674Z"
 }

--- a/plugin/dist/build-manifest.json
+++ b/plugin/dist/build-manifest.json
@@ -2,5 +2,5 @@
   "entrypoint": "skill-creator.ts",
   "runtimeEntrypoint": "runtime-entry.ts",
   "sourceHash": "1bc2a2e2b02cfbbff2c6100d940b5c56bbcd9bd3e923c7d30e080b3b509ef164",
-  "builtAt": "2026-05-25T04:18:44.674Z"
+  "builtAt": "2026-05-25T04:24:15.717Z"
 }

--- a/plugin/dist/build-manifest.json
+++ b/plugin/dist/build-manifest.json
@@ -2,5 +2,5 @@
   "entrypoint": "skill-creator.ts",
   "runtimeEntrypoint": "runtime-entry.ts",
   "sourceHash": "1bc2a2e2b02cfbbff2c6100d940b5c56bbcd9bd3e923c7d30e080b3b509ef164",
-  "builtAt": "2026-05-24T23:12:56.138Z"
+  "builtAt": "2026-05-25T04:14:58.551Z"
 }

--- a/plugin/dist/package.json
+++ b/plugin/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-skill-creator",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "OpenCode plugin for skill creation — custom tools for validation, evaluation, description optimization, benchmarking, and review serving.",
   "type": "module",
   "main": "./dist/skill-creator.js",

--- a/plugin/test/workflow.test.mjs
+++ b/plugin/test/workflow.test.mjs
@@ -19,6 +19,10 @@ test("publish workflow uses npm trusted publishing provenance", () => {
   const workflow = readFileSync(publishWorkflowPath, "utf-8")
 
   assert.match(workflow, /permissions:\s+contents:\s*write\s+id-token:\s*write/s)
+  assert.match(
+    workflow,
+    /if:\s*steps\.npm\.outputs\.exists != 'true' && github\.repository == 'antongulin\/opencode-skill-creator' && github\.ref == 'refs\/heads\/main'\s+run:\s*npm publish --access public --provenance/s,
+  )
   assert.match(workflow, /run:\s*npm publish --access public --provenance\s+working-directory:\s*plugin/s)
   assert.doesNotMatch(workflow, /NODE_AUTH_TOKEN/)
 })

--- a/plugin/test/workflow.test.mjs
+++ b/plugin/test/workflow.test.mjs
@@ -12,5 +12,13 @@ test("publish workflow prepares dependencies required by prepack", () => {
 
   assert.match(workflow, /oven-sh\/setup-bun@v\d+/)
   assert.match(workflow, /working-directory:\s*plugin\s+run:\s*npm install/s)
-  assert.match(workflow, /run:\s*npm publish --access public\s+working-directory:\s*plugin/s)
+  assert.match(workflow, /run:\s*npm publish --access public --provenance\s+working-directory:\s*plugin/s)
+})
+
+test("publish workflow uses npm trusted publishing provenance", () => {
+  const workflow = readFileSync(publishWorkflowPath, "utf-8")
+
+  assert.match(workflow, /permissions:\s+contents:\s*write\s+id-token:\s*write/s)
+  assert.match(workflow, /run:\s*npm publish --access public --provenance\s+working-directory:\s*plugin/s)
+  assert.doesNotMatch(workflow, /NODE_AUTH_TOKEN/)
 })

--- a/plugin/test/workflow.test.mjs
+++ b/plugin/test/workflow.test.mjs
@@ -19,6 +19,8 @@ test("publish workflow uses npm trusted publishing provenance", () => {
   const workflow = readFileSync(publishWorkflowPath, "utf-8")
 
   assert.match(workflow, /permissions:\s+contents:\s*write\s+id-token:\s*write/s)
+  assert.match(workflow, /trusted publishing is bound to this repository\/workflow/)
+  assert.match(workflow, /forks and non-main refs cannot publish/)
   assert.match(
     workflow,
     /if:\s*steps\.npm\.outputs\.exists != 'true' && github\.repository == 'antongulin\/opencode-skill-creator' && github\.ref == 'refs\/heads\/main'\s+run:\s*npm publish --access public --provenance/s,


### PR DESCRIPTION
## Summary
- switch npm publishing to trusted publishing with provenance
- grant GitHub Actions OIDC token permission for npm publish
- add workflow regression coverage that rejects NODE_AUTH_TOKEN publishing

## Test Plan
- npm run prepack
- npm publish --dry-run --access public --provenance

## Setup Required
- Configure npm trusted publisher for package `opencode-skill-creator`:
  - Repository: `antongulin/opencode-skill-creator`
  - Workflow: `.github/workflows/publish.yml`
  - Environment: none