### PR TITLE
fix(runtime): remove remaining Bun spawn usage

### DIFF
--- a/plugin/dist/build-manifest.json
+++ b/plugin/dist/build-manifest.json
@@ -1,6 +1,6 @@
 {
   "entrypoint": "skill-creator.ts",
   "runtimeEntrypoint": "runtime-entry.ts",
-  "sourceHash": "81ff05c87f81c259385c5ce7fe4df7231cc9402271d76936284e4635d58a606c",
-  "builtAt": "2026-05-25T05:53:19.807Z"
+  "sourceHash": "8678973957ff0454c6e8b0d6fbd9cb06f83ea481fe99903d6702006cb12f24b3",
+  "builtAt": "2026-05-25T06:05:02.694Z"
 }

--- a/plugin/dist/build-manifest.json
+++ b/plugin/dist/build-manifest.json
@@ -1,6 +1,6 @@
 {
   "entrypoint": "skill-creator.ts",
   "runtimeEntrypoint": "runtime-entry.ts",
-  "sourceHash": "8678973957ff0454c6e8b0d6fbd9cb06f83ea481fe99903d6702006cb12f24b3",
-  "builtAt": "2026-05-25T06:05:02.694Z"
+  "sourceHash": "4de077a66c3aab84981af7743c4b635793766e22ef052d286e910124a3d23a57",
+  "builtAt": "2026-05-25T06:12:33.073Z"
 }

--- a/plugin/dist/build-manifest.json
+++ b/plugin/dist/build-manifest.json
@@ -1,6 +1,6 @@
 {
   "entrypoint": "skill-creator.ts",
   "runtimeEntrypoint": "runtime-entry.ts",
-  "sourceHash": "625a08874bb29f3729f7b05860e6bc01538f64548d9f02902c192f04ed6339f9",
-  "builtAt": "2026-05-25T05:40:58.976Z"
+  "sourceHash": "81ff05c87f81c259385c5ce7fe4df7231cc9402271d76936284e4635d58a606c",
+  "builtAt": "2026-05-25T05:53:19.807Z"
 }

--- a/plugin/dist/build-manifest.json
+++ b/plugin/dist/build-manifest.json
@@ -1,6 +1,6 @@
 {
   "entrypoint": "skill-creator.ts",
   "runtimeEntrypoint": "runtime-entry.ts",
-  "sourceHash": "4de077a66c3aab84981af7743c4b635793766e22ef052d286e910124a3d23a57",
-  "builtAt": "2026-05-25T06:12:33.073Z"
+  "sourceHash": "2d062d73b563100ef01b0a1cc1693fb36c063d2ffcf2fa92828b3ada844c80c2",
+  "builtAt": "2026-05-25T06:32:15.069Z"
 }

--- a/plugin/dist/build-manifest.json
+++ b/plugin/dist/build-manifest.json
@@ -1,6 +1,6 @@
 {
   "entrypoint": "skill-creator.ts",
   "runtimeEntrypoint": "runtime-entry.ts",
-  "sourceHash": "1bc2a2e2b02cfbbff2c6100d940b5c56bbcd9bd3e923c7d30e080b3b509ef164",
-  "builtAt": "2026-05-25T05:08:46.548Z"
+  "sourceHash": "625a08874bb29f3729f7b05860e6bc01538f64548d9f02902c192f04ed6339f9",
+  "builtAt": "2026-05-25T05:40:58.976Z"
 }

--- a/plugin/dist/skill-creator.js
+++ b/plugin/dist/skill-creator.js
@@ -12518,6 +12518,9 @@ import { randomBytes } from "crypto";
 
 // lib/process.ts
 import { spawn } from "child_process";
+function isFailedExitCode(exitCode) {
+  return exitCode != null && exitCode !== 0;
+}
 function runProcess(command, opts) {
   return new Promise((resolve, reject) => {
     const [file2, ...args] = command;
@@ -12686,7 +12689,7 @@ async function runSingleQuery(query, skillName, skillDescription, timeout, proje
       }
     });
     flushBuffer(true);
-    if (result.exitCode !== 0) {
+    if (isFailedExitCode(result.exitCode)) {
       const cleanedStderr = result.stderr.trim();
       throw new Error(cleanedStderr ? `opencode run exited ${result.exitCode}: ${cleanedStderr}` : `opencode run exited ${result.exitCode}`);
     }
@@ -12889,7 +12892,7 @@ async function callOpenCode(prompt, model, timeout = 300) {
       }
     });
     flushLines(true);
-    if (result.exitCode !== 0) {
+    if (isFailedExitCode(result.exitCode)) {
       throw new Error(`opencode run exited ${result.exitCode}
 stderr: ${result.stderr}`);
     }

--- a/plugin/dist/skill-creator.js
+++ b/plugin/dist/skill-creator.js
@@ -12521,6 +12521,9 @@ import { spawn } from "child_process";
 function isFailedExitCode(exitCode) {
   return exitCode != null && exitCode !== 0;
 }
+function isFailedProcess(result) {
+  return result.timedOut || isFailedExitCode(result.exitCode);
+}
 function runProcess(command, opts) {
   return new Promise((resolve, reject) => {
     const [file2, ...args] = command;
@@ -12689,7 +12692,7 @@ async function runSingleQuery(query, skillName, skillDescription, timeout, proje
       }
     });
     flushBuffer(true);
-    if (isFailedExitCode(result.exitCode)) {
+    if (isFailedProcess(result)) {
       const cleanedStderr = result.stderr.trim();
       throw new Error(cleanedStderr ? `opencode run exited ${result.exitCode}: ${cleanedStderr}` : `opencode run exited ${result.exitCode}`);
     }
@@ -12892,7 +12895,7 @@ async function callOpenCode(prompt, model, timeout = 300) {
       }
     });
     flushLines(true);
-    if (isFailedExitCode(result.exitCode)) {
+    if (isFailedProcess(result)) {
       throw new Error(`opencode run exited ${result.exitCode}
 stderr: ${result.stderr}`);
     }

--- a/plugin/dist/skill-creator.js
+++ b/plugin/dist/skill-creator.js
@@ -12515,6 +12515,61 @@ function parseSkillMd(skillPath) {
 import { existsSync as existsSync2, mkdirSync, rmSync, writeFileSync } from "fs";
 import { dirname, join as join3, parse as parse5 } from "path";
 import { randomBytes } from "crypto";
+
+// lib/process.ts
+import { spawn } from "child_process";
+function runProcess(command, opts) {
+  return new Promise((resolve, reject) => {
+    const [file2, ...args] = command;
+    if (!file2) {
+      reject(new Error("Cannot spawn an empty command"));
+      return;
+    }
+    const maxStderrChars = opts.maxStderrChars ?? 64 * 1024;
+    const proc = spawn(file2, args, {
+      cwd: opts.cwd,
+      env: opts.env,
+      stdout: "pipe",
+      stderr: "pipe"
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let settled = false;
+    const timeoutId = setTimeout(() => {
+      timedOut = true;
+      proc.kill();
+    }, opts.timeoutMs);
+    proc.stdout.setEncoding("utf-8");
+    proc.stdout.on("data", (chunk) => {
+      stdout += chunk;
+      opts.onStdoutChunk?.(chunk);
+    });
+    proc.stderr.setEncoding("utf-8");
+    proc.stderr.on("data", (chunk) => {
+      stderr += chunk;
+      if (stderr.length > maxStderrChars) {
+        stderr = stderr.slice(-maxStderrChars);
+      }
+    });
+    proc.on("error", (error45) => {
+      if (settled)
+        return;
+      settled = true;
+      clearTimeout(timeoutId);
+      reject(error45);
+    });
+    proc.on("close", (exitCode) => {
+      if (settled)
+        return;
+      settled = true;
+      clearTimeout(timeoutId);
+      resolve({ exitCode, stdout, stderr, timedOut });
+    });
+  });
+}
+
+// lib/run-eval.ts
 var SKILL_NAME_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 var ALL_ZERO_WARNING = "All should-trigger queries produced 0 triggers with no run errors. Check that trigger evals are using an agent that exposes skill tool events, such as the build agent.";
 function buildOpenCodeRunCommand(query, opts) {
@@ -12581,42 +12636,10 @@ async function runSingleQuery(query, skillName, skillDescription, timeout, proje
 `);
     writeFileSync(skillFile, skillContent);
     const cmd = buildOpenCodeRunCommand(query, { agent, model });
-    const proc = Bun.spawn(cmd, {
-      cwd: projectRoot,
-      stdout: "pipe",
-      stderr: "pipe",
-      env: { ...process.env }
-    });
     let buffer = "";
     let triggered = false;
-    const decoder = new TextDecoder;
-    const reader = proc.stdout.getReader();
-    const stderrReader = proc.stderr.getReader();
-    const stderrDecoder = new TextDecoder;
     const maxStderrChars = 64 * 1024;
-    let stderrTail = "";
     const timeoutMs = timeout * 1000;
-    const stderrDrained = (async () => {
-      try {
-        while (true) {
-          const result = await stderrReader.read();
-          if (result.done)
-            break;
-          if (!result.value)
-            continue;
-          stderrTail += stderrDecoder.decode(result.value, { stream: true });
-          if (stderrTail.length > maxStderrChars) {
-            stderrTail = stderrTail.slice(-maxStderrChars);
-          }
-        }
-        stderrTail += stderrDecoder.decode();
-        if (stderrTail.length > maxStderrChars) {
-          stderrTail = stderrTail.slice(-maxStderrChars);
-        }
-      } finally {
-        stderrReader.releaseLock();
-      }
-    })();
     const consumeLine = (line) => {
       const trimmed = line.trim();
       if (!trimmed)
@@ -12652,42 +12675,20 @@ async function runSingleQuery(query, skillName, skillDescription, timeout, proje
         buffer = "";
       }
     };
-    const timeoutId = setTimeout(() => {
-      if (proc.exitCode === null) {
-        proc.kill();
+    const result = await runProcess(cmd, {
+      cwd: projectRoot,
+      env: { ...process.env },
+      timeoutMs,
+      maxStderrChars,
+      onStdoutChunk(chunk) {
+        buffer += chunk;
+        flushBuffer();
       }
-    }, timeoutMs);
-    try {
-      while (true) {
-        const result = await reader.read();
-        if (result.done)
-          break;
-        if (result.value) {
-          buffer += decoder.decode(result.value, { stream: true });
-          flushBuffer();
-        }
-      }
-      const finalChunk = decoder.decode();
-      if (finalChunk) {
-        buffer += finalChunk;
-      }
-      flushBuffer(true);
-      await proc.exited;
-      await stderrDrained;
-      if ((proc.exitCode ?? 0) !== 0) {
-        const cleanedStderr = stderrTail.trim();
-        throw new Error(cleanedStderr ? `opencode run exited ${proc.exitCode}: ${cleanedStderr}` : `opencode run exited ${proc.exitCode}`);
-      }
-    } finally {
-      clearTimeout(timeoutId);
-      reader.releaseLock();
-      if (proc.exitCode === null) {
-        proc.kill();
-        await proc.exited;
-      }
-      await stderrDrained.catch(() => {
-        return;
-      });
+    });
+    flushBuffer(true);
+    if (result.exitCode !== 0) {
+      const cleanedStderr = result.stderr.trim();
+      throw new Error(cleanedStderr ? `opencode run exited ${result.exitCode}: ${cleanedStderr}` : `opencode run exited ${result.exitCode}`);
     }
     return triggered;
   } finally {
@@ -12840,42 +12841,11 @@ async function callOpenCode(prompt, model, timeout = 300) {
     if (model)
       cmd.push("--model", model);
     cmd.push("--file", tmpPath, "--", "Process the attached file and follow its instructions.");
-    const proc = Bun.spawn(cmd, {
-      stdout: "pipe",
-      stderr: "pipe",
-      env: { ...process.env }
-    });
     let stdout = "";
     let lineBuffer = "";
     const textParts = [];
-    const decoder = new TextDecoder;
-    const reader = proc.stdout.getReader();
-    const stderrReader = proc.stderr.getReader();
-    const stderrDecoder = new TextDecoder;
     const maxStderrChars = 64 * 1024;
-    let stderrTail = "";
     const timeoutMs = timeout * 1000;
-    const stderrDrained = (async () => {
-      try {
-        while (true) {
-          const result = await stderrReader.read();
-          if (result.done)
-            break;
-          if (!result.value)
-            continue;
-          stderrTail += stderrDecoder.decode(result.value, { stream: true });
-          if (stderrTail.length > maxStderrChars) {
-            stderrTail = stderrTail.slice(-maxStderrChars);
-          }
-        }
-        stderrTail += stderrDecoder.decode();
-        if (stderrTail.length > maxStderrChars) {
-          stderrTail = stderrTail.slice(-maxStderrChars);
-        }
-      } finally {
-        stderrReader.releaseLock();
-      }
-    })();
     const consumeLine = (line) => {
       const trimmed = line.trim();
       if (!trimmed)
@@ -12908,45 +12878,20 @@ async function callOpenCode(prompt, model, timeout = 300) {
         lineBuffer = "";
       }
     };
-    const timeoutId = setTimeout(() => {
-      if (proc.exitCode === null) {
-        proc.kill();
+    const result = await runProcess(cmd, {
+      env: { ...process.env },
+      timeoutMs,
+      maxStderrChars,
+      onStdoutChunk(chunk) {
+        stdout += chunk;
+        lineBuffer += chunk;
+        flushLines();
       }
-    }, timeoutMs);
-    try {
-      while (true) {
-        const result = await reader.read();
-        if (result.done)
-          break;
-        if (result.value) {
-          const chunk = decoder.decode(result.value, { stream: true });
-          stdout += chunk;
-          lineBuffer += chunk;
-          flushLines();
-        }
-      }
-      const finalChunk = decoder.decode();
-      if (finalChunk) {
-        stdout += finalChunk;
-        lineBuffer += finalChunk;
-      }
-      flushLines(true);
-      await proc.exited;
-      await stderrDrained;
-    } finally {
-      clearTimeout(timeoutId);
-      reader.releaseLock();
-      if (proc.exitCode === null) {
-        proc.kill();
-        await proc.exited;
-      }
-      await stderrDrained.catch(() => {
-        return;
-      });
-    }
-    if (proc.exitCode !== 0 && proc.exitCode !== null) {
-      throw new Error(`opencode run exited ${proc.exitCode}
-stderr: ${stderrTail}`);
+    });
+    flushLines(true);
+    if (result.exitCode !== 0) {
+      throw new Error(`opencode run exited ${result.exitCode}
+stderr: ${result.stderr}`);
     }
     if (textParts.length > 0) {
       return textParts.join("");
@@ -13928,7 +13873,7 @@ function generateMarkdown(benchmark) {
 }
 
 // lib/review-server.ts
-import { spawn } from "child_process";
+import { spawn as spawn2 } from "child_process";
 import {
   existsSync as existsSync4,
   mkdirSync as mkdirSync3,
@@ -14243,7 +14188,7 @@ function readStream(stream, maxBytes) {
 }
 function runCommand(command, args) {
   return new Promise((resolve) => {
-    const proc = spawn(command, args, {
+    const proc = spawn2(command, args, {
       stdout: "pipe",
       stderr: "ignore"
     });
@@ -14427,7 +14372,7 @@ async function serveReview(opts) {
   const serverUrl = `http://localhost:${actualPort}`;
   if (openBrowser) {
     try {
-      const openProc = spawn("open", [serverUrl], {
+      const openProc = spawn2("open", [serverUrl], {
         detached: true,
         stdio: "ignore"
       });

--- a/plugin/dist/skill-creator.js
+++ b/plugin/dist/skill-creator.js
@@ -12532,6 +12532,7 @@ function runProcess(command, opts) {
       return;
     }
     const maxStderrChars = opts.maxStderrChars ?? 64 * 1024;
+    const killGraceMs = opts.killGraceMs ?? 1000;
     const proc = spawn(file2, args, {
       cwd: opts.cwd,
       env: opts.env,
@@ -12542,9 +12543,15 @@ function runProcess(command, opts) {
     let stderr = "";
     let timedOut = false;
     let settled = false;
+    let killTimeoutId;
     const timeoutId = setTimeout(() => {
       timedOut = true;
       proc.kill();
+      killTimeoutId = setTimeout(() => {
+        if (!settled) {
+          proc.kill("SIGKILL");
+        }
+      }, killGraceMs);
     }, opts.timeoutMs);
     proc.stdout.setEncoding("utf-8");
     proc.stdout.on("data", (chunk) => {
@@ -12563,6 +12570,8 @@ function runProcess(command, opts) {
         return;
       settled = true;
       clearTimeout(timeoutId);
+      if (killTimeoutId)
+        clearTimeout(killTimeoutId);
       reject(error45);
     });
     proc.on("close", (exitCode) => {
@@ -12570,6 +12579,8 @@ function runProcess(command, opts) {
         return;
       settled = true;
       clearTimeout(timeoutId);
+      if (killTimeoutId)
+        clearTimeout(killTimeoutId);
       resolve({ exitCode, stdout, stderr, timedOut });
     });
   });

--- a/plugin/lib/improve-description.ts
+++ b/plugin/lib/improve-description.ts
@@ -18,7 +18,7 @@ import {
   classifyEvalFailures,
   formatFailureDiagnostics,
 } from "./failure-taxonomy"
-import { runProcess } from "./process"
+import { isFailedExitCode, runProcess } from "./process"
 import type { EvalOutput, EvalResultItem } from "./run-eval"
 
 // ---------------------------------------------------------------------------
@@ -96,7 +96,7 @@ async function callOpenCode(
 
     flushLines(true)
 
-    if (result.exitCode !== 0) {
+    if (isFailedExitCode(result.exitCode)) {
       throw new Error(`opencode run exited ${result.exitCode}\nstderr: ${result.stderr}`)
     }
 

--- a/plugin/lib/improve-description.ts
+++ b/plugin/lib/improve-description.ts
@@ -18,7 +18,7 @@ import {
   classifyEvalFailures,
   formatFailureDiagnostics,
 } from "./failure-taxonomy"
-import { isFailedExitCode, runProcess } from "./process"
+import { isFailedProcess, runProcess } from "./process"
 import type { EvalOutput, EvalResultItem } from "./run-eval"
 
 // ---------------------------------------------------------------------------
@@ -96,7 +96,7 @@ async function callOpenCode(
 
     flushLines(true)
 
-    if (isFailedExitCode(result.exitCode)) {
+    if (isFailedProcess(result)) {
       throw new Error(`opencode run exited ${result.exitCode}\nstderr: ${result.stderr}`)
     }
 

--- a/plugin/lib/improve-description.ts
+++ b/plugin/lib/improve-description.ts
@@ -4,7 +4,7 @@
  *
  * Port of scripts/improve_description.py.
  *
- * Uses `Bun.$` to call `opencode run` with a temp file prompt (via --file).
+ * Uses Node child_process to call `opencode run` with a temp file prompt (via --file).
  * Parses `<new_description>` tags from the response. Retries once if the
  * description exceeds 1024 characters.
  */
@@ -18,6 +18,7 @@ import {
   classifyEvalFailures,
   formatFailureDiagnostics,
 } from "./failure-taxonomy"
+import { runProcess } from "./process"
 import type { EvalOutput, EvalResultItem } from "./run-eval"
 
 // ---------------------------------------------------------------------------
@@ -42,45 +43,12 @@ async function callOpenCode(
     // as a positional message instead of another --file value.
     cmd.push("--file", tmpPath, "--", "Process the attached file and follow its instructions.")
 
-    const proc = Bun.spawn(cmd, {
-      stdout: "pipe",
-      stderr: "pipe",
-      env: { ...process.env },
-    })
-
     // Collect stdout with timeout. Prefer structured text events from JSON mode.
     let stdout = ""
     let lineBuffer = ""
     const textParts: string[] = []
-    const decoder = new TextDecoder()
-    const reader = proc.stdout.getReader()
-    const stderrReader = proc.stderr.getReader()
-    const stderrDecoder = new TextDecoder()
     const maxStderrChars = 64 * 1024
-    let stderrTail = ""
     const timeoutMs = timeout * 1000
-
-    const stderrDrained = (async () => {
-      try {
-        while (true) {
-          const result = await stderrReader.read()
-          if (result.done) break
-          if (!result.value) continue
-
-          stderrTail += stderrDecoder.decode(result.value, { stream: true })
-          if (stderrTail.length > maxStderrChars) {
-            stderrTail = stderrTail.slice(-maxStderrChars)
-          }
-        }
-
-        stderrTail += stderrDecoder.decode()
-        if (stderrTail.length > maxStderrChars) {
-          stderrTail = stderrTail.slice(-maxStderrChars)
-        }
-      } finally {
-        stderrReader.releaseLock()
-      }
-    })()
 
     const consumeLine = (line: string) => {
       const trimmed = line.trim()
@@ -115,47 +83,21 @@ async function callOpenCode(
       }
     }
 
-    const timeoutId = setTimeout(() => {
-      if (proc.exitCode === null) {
-        proc.kill()
-      }
-    }, timeoutMs)
+    const result = await runProcess(cmd, {
+      env: { ...process.env },
+      timeoutMs,
+      maxStderrChars,
+      onStdoutChunk(chunk) {
+        stdout += chunk
+        lineBuffer += chunk
+        flushLines()
+      },
+    })
 
-    try {
-      while (true) {
-        const result = await reader.read()
-        if (result.done) break
-        if (result.value) {
-          const chunk = decoder.decode(result.value, { stream: true })
-          stdout += chunk
-          lineBuffer += chunk
-          flushLines()
-        }
-      }
+    flushLines(true)
 
-      const finalChunk = decoder.decode()
-      if (finalChunk) {
-        stdout += finalChunk
-        lineBuffer += finalChunk
-      }
-
-      flushLines(true)
-      await proc.exited
-      await stderrDrained
-    } finally {
-      clearTimeout(timeoutId)
-      reader.releaseLock()
-
-      if (proc.exitCode === null) {
-        proc.kill()
-        await proc.exited
-      }
-
-      await stderrDrained.catch(() => undefined)
-    }
-
-    if (proc.exitCode !== 0 && proc.exitCode !== null) {
-      throw new Error(`opencode run exited ${proc.exitCode}\nstderr: ${stderrTail}`)
+    if (result.exitCode !== 0) {
+      throw new Error(`opencode run exited ${result.exitCode}\nstderr: ${result.stderr}`)
     }
 
     if (textParts.length > 0) {

--- a/plugin/lib/process.ts
+++ b/plugin/lib/process.ts
@@ -19,10 +19,15 @@ export function isFailedExitCode(exitCode: number | null): boolean {
   return exitCode != null && exitCode !== 0
 }
 
+export function isFailedProcess(result: RunProcessResult): boolean {
+  return result.timedOut || isFailedExitCode(result.exitCode)
+}
+
 /**
  * Spawn a command without a shell, collect stdout/stderr, and optionally stream
  * stdout chunks to a parser. Rejects only when the process cannot be spawned;
- * callers decide how to handle exit codes, null exits, and timeouts.
+ * callers decide how to handle exit codes and timeouts. Use `timedOut` to
+ * distinguish timeouts from other null-exit process states.
  */
 export function runProcess(command: string[], opts: RunProcessOptions): Promise<RunProcessResult> {
   return new Promise((resolve, reject) => {

--- a/plugin/lib/process.ts
+++ b/plugin/lib/process.ts
@@ -15,6 +15,10 @@ export interface RunProcessResult {
   timedOut: boolean
 }
 
+export function isFailedExitCode(exitCode: number | null): boolean {
+  return exitCode != null && exitCode !== 0
+}
+
 export function runProcess(command: string[], opts: RunProcessOptions): Promise<RunProcessResult> {
   return new Promise((resolve, reject) => {
     const [file, ...args] = command

--- a/plugin/lib/process.ts
+++ b/plugin/lib/process.ts
@@ -19,6 +19,11 @@ export function isFailedExitCode(exitCode: number | null): boolean {
   return exitCode != null && exitCode !== 0
 }
 
+/**
+ * Spawn a command without a shell, collect stdout/stderr, and optionally stream
+ * stdout chunks to a parser. Rejects only when the process cannot be spawned;
+ * callers decide how to handle exit codes, null exits, and timeouts.
+ */
 export function runProcess(command: string[], opts: RunProcessOptions): Promise<RunProcessResult> {
   return new Promise((resolve, reject) => {
     const [file, ...args] = command

--- a/plugin/lib/process.ts
+++ b/plugin/lib/process.ts
@@ -1,0 +1,71 @@
+import { spawn } from "node:child_process"
+
+interface RunProcessOptions {
+  cwd?: string
+  env?: NodeJS.ProcessEnv
+  timeoutMs: number
+  maxStderrChars?: number
+  onStdoutChunk?: (chunk: string) => void
+}
+
+export interface RunProcessResult {
+  exitCode: number | null
+  stdout: string
+  stderr: string
+  timedOut: boolean
+}
+
+export function runProcess(command: string[], opts: RunProcessOptions): Promise<RunProcessResult> {
+  return new Promise((resolve, reject) => {
+    const [file, ...args] = command
+    if (!file) {
+      reject(new Error("Cannot spawn an empty command"))
+      return
+    }
+
+    const maxStderrChars = opts.maxStderrChars ?? 64 * 1024
+    const proc = spawn(file, args, {
+      cwd: opts.cwd,
+      env: opts.env,
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    let stdout = ""
+    let stderr = ""
+    let timedOut = false
+    let settled = false
+
+    const timeoutId = setTimeout(() => {
+      timedOut = true
+      proc.kill()
+    }, opts.timeoutMs)
+
+    proc.stdout.setEncoding("utf-8")
+    proc.stdout.on("data", (chunk: string) => {
+      stdout += chunk
+      opts.onStdoutChunk?.(chunk)
+    })
+
+    proc.stderr.setEncoding("utf-8")
+    proc.stderr.on("data", (chunk: string) => {
+      stderr += chunk
+      if (stderr.length > maxStderrChars) {
+        stderr = stderr.slice(-maxStderrChars)
+      }
+    })
+
+    proc.on("error", (error) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeoutId)
+      reject(error)
+    })
+
+    proc.on("close", (exitCode) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeoutId)
+      resolve({ exitCode, stdout, stderr, timedOut })
+    })
+  })
+}

--- a/plugin/lib/process.ts
+++ b/plugin/lib/process.ts
@@ -4,6 +4,7 @@ interface RunProcessOptions {
   cwd?: string
   env?: NodeJS.ProcessEnv
   timeoutMs: number
+  killGraceMs?: number
   maxStderrChars?: number
   onStdoutChunk?: (chunk: string) => void
 }
@@ -38,6 +39,7 @@ export function runProcess(command: string[], opts: RunProcessOptions): Promise<
     }
 
     const maxStderrChars = opts.maxStderrChars ?? 64 * 1024
+    const killGraceMs = opts.killGraceMs ?? 1_000
     const proc = spawn(file, args, {
       cwd: opts.cwd,
       env: opts.env,
@@ -48,10 +50,16 @@ export function runProcess(command: string[], opts: RunProcessOptions): Promise<
     let stderr = ""
     let timedOut = false
     let settled = false
+    let killTimeoutId: ReturnType<typeof setTimeout> | undefined
 
     const timeoutId = setTimeout(() => {
       timedOut = true
       proc.kill()
+      killTimeoutId = setTimeout(() => {
+        if (!settled) {
+          proc.kill("SIGKILL")
+        }
+      }, killGraceMs)
     }, opts.timeoutMs)
 
     proc.stdout.setEncoding("utf-8")
@@ -72,6 +80,7 @@ export function runProcess(command: string[], opts: RunProcessOptions): Promise<
       if (settled) return
       settled = true
       clearTimeout(timeoutId)
+      if (killTimeoutId) clearTimeout(killTimeoutId)
       reject(error)
     })
 
@@ -79,6 +88,7 @@ export function runProcess(command: string[], opts: RunProcessOptions): Promise<
       if (settled) return
       settled = true
       clearTimeout(timeoutId)
+      if (killTimeoutId) clearTimeout(killTimeoutId)
       resolve({ exitCode, stdout, stderr, timedOut })
     })
   })

--- a/plugin/lib/run-eval.ts
+++ b/plugin/lib/run-eval.ts
@@ -14,7 +14,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs"
 import { dirname, join, parse } from "path"
 import { randomBytes } from "crypto"
 
-import { isFailedExitCode, runProcess } from "./process"
+import { isFailedProcess, runProcess } from "./process"
 
 const SKILL_NAME_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 
@@ -206,7 +206,7 @@ async function runSingleQuery(
 
     flushBuffer(true)
 
-    if (isFailedExitCode(result.exitCode)) {
+    if (isFailedProcess(result)) {
       const cleanedStderr = result.stderr.trim()
       throw new Error(
         cleanedStderr

--- a/plugin/lib/run-eval.ts
+++ b/plugin/lib/run-eval.ts
@@ -14,7 +14,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs"
 import { dirname, join, parse } from "path"
 import { randomBytes } from "crypto"
 
-import { runProcess } from "./process"
+import { isFailedExitCode, runProcess } from "./process"
 
 const SKILL_NAME_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 
@@ -206,7 +206,7 @@ async function runSingleQuery(
 
     flushBuffer(true)
 
-    if (result.exitCode !== 0) {
+    if (isFailedExitCode(result.exitCode)) {
       const cleanedStderr = result.stderr.trim()
       throw new Error(
         cleanedStderr

--- a/plugin/lib/run-eval.ts
+++ b/plugin/lib/run-eval.ts
@@ -4,7 +4,7 @@
  *
  * Port of scripts/run_eval.py.
  *
- * Uses `Bun.$` to shell out to `opencode run`. For each query a temporary
+ * Uses Node child_process to shell out to `opencode run`. For each query a temporary
  * skill is created in .opencode/skills/ so it appears in the available_skills
  * list. The output is scanned for the temporary skill name to determine
  * whether the skill was triggered.
@@ -13,6 +13,8 @@
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs"
 import { dirname, join, parse } from "path"
 import { randomBytes } from "crypto"
+
+import { runProcess } from "./process"
 
 const SKILL_NAME_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 
@@ -147,45 +149,11 @@ async function runSingleQuery(
 
     const cmd = buildOpenCodeRunCommand(query, { agent, model })
 
-    const proc = Bun.spawn(cmd, {
-      cwd: projectRoot,
-      stdout: "pipe",
-      stderr: "pipe",
-      env: { ...process.env },
-    })
-
     // Collect output with timeout and detect skill invocation from JSON events.
     let buffer = ""
     let triggered = false
-    const decoder = new TextDecoder()
-    const reader = proc.stdout.getReader()
-    const stderrReader = proc.stderr.getReader()
-    const stderrDecoder = new TextDecoder()
     const maxStderrChars = 64 * 1024
-    let stderrTail = ""
     const timeoutMs = timeout * 1000
-
-    const stderrDrained = (async () => {
-      try {
-        while (true) {
-          const result = await stderrReader.read()
-          if (result.done) break
-          if (!result.value) continue
-
-          stderrTail += stderrDecoder.decode(result.value, { stream: true })
-          if (stderrTail.length > maxStderrChars) {
-            stderrTail = stderrTail.slice(-maxStderrChars)
-          }
-        }
-
-        stderrTail += stderrDecoder.decode()
-        if (stderrTail.length > maxStderrChars) {
-          stderrTail = stderrTail.slice(-maxStderrChars)
-        }
-      } finally {
-        stderrReader.releaseLock()
-      }
-    })()
 
     const consumeLine = (line: string) => {
       const trimmed = line.trim()
@@ -225,49 +193,26 @@ async function runSingleQuery(
       }
     }
 
-    const timeoutId = setTimeout(() => {
-      if (proc.exitCode === null) {
-        proc.kill()
-      }
-    }, timeoutMs)
+    const result = await runProcess(cmd, {
+      cwd: projectRoot,
+      env: { ...process.env },
+      timeoutMs,
+      maxStderrChars,
+      onStdoutChunk(chunk) {
+        buffer += chunk
+        flushBuffer()
+      },
+    })
 
-    try {
-      while (true) {
-        const result = await reader.read()
-        if (result.done) break
-        if (result.value) {
-          buffer += decoder.decode(result.value, { stream: true })
-          flushBuffer()
-        }
-      }
+    flushBuffer(true)
 
-      const finalChunk = decoder.decode()
-      if (finalChunk) {
-        buffer += finalChunk
-      }
-
-      flushBuffer(true)
-      await proc.exited
-      await stderrDrained
-
-      if ((proc.exitCode ?? 0) !== 0) {
-        const cleanedStderr = stderrTail.trim()
-        throw new Error(
-          cleanedStderr
-            ? `opencode run exited ${proc.exitCode}: ${cleanedStderr}`
-            : `opencode run exited ${proc.exitCode}`,
-        )
-      }
-    } finally {
-      clearTimeout(timeoutId)
-      reader.releaseLock()
-
-      if (proc.exitCode === null) {
-        proc.kill()
-        await proc.exited
-      }
-
-      await stderrDrained.catch(() => undefined)
+    if (result.exitCode !== 0) {
+      const cleanedStderr = result.stderr.trim()
+      throw new Error(
+        cleanedStderr
+          ? `opencode run exited ${result.exitCode}: ${cleanedStderr}`
+          : `opencode run exited ${result.exitCode}`,
+      )
     }
 
     return triggered

--- a/plugin/test/package.test.mjs
+++ b/plugin/test/package.test.mjs
@@ -99,6 +99,12 @@ test("compiled entrypoint only exposes plugin functions for legacy OpenCode load
   assert.equal(typeof mod.default, "function")
 })
 
+test("compiled entrypoint does not depend on Bun runtime APIs", () => {
+  const source = readFileSync(distEntryPath, "utf-8")
+
+  assert.doesNotMatch(source, /\bBun\b/)
+})
+
 test("compiled review server runs in Node without a Bun runtime global", async () => {
   assert.equal(globalThis.Bun, undefined)
 

--- a/plugin/test/process.test.ts
+++ b/plugin/test/process.test.ts
@@ -1,11 +1,23 @@
 import { expect, test } from "bun:test"
 
-import { isFailedExitCode, runProcess } from "../lib/process"
+import { isFailedExitCode, isFailedProcess, runProcess } from "../lib/process"
 
 test("isFailedExitCode treats only defined non-zero exit codes as failures", () => {
   expect(isFailedExitCode(1)).toBe(true)
   expect(isFailedExitCode(0)).toBe(false)
   expect(isFailedExitCode(null)).toBe(false)
+})
+
+test("isFailedProcess treats timeouts as failures without changing null exit semantics", () => {
+  expect(
+    isFailedProcess({ exitCode: null, stdout: "", stderr: "", timedOut: true }),
+  ).toBe(true)
+  expect(
+    isFailedProcess({ exitCode: null, stdout: "", stderr: "", timedOut: false }),
+  ).toBe(false)
+  expect(
+    isFailedProcess({ exitCode: 1, stdout: "", stderr: "", timedOut: false }),
+  ).toBe(true)
 })
 
 test("runProcess reports timeouts without treating null exits as failures", async () => {

--- a/plugin/test/process.test.ts
+++ b/plugin/test/process.test.ts
@@ -1,9 +1,37 @@
 import { expect, test } from "bun:test"
 
-import { isFailedExitCode } from "../lib/process"
+import { isFailedExitCode, runProcess } from "../lib/process"
 
 test("isFailedExitCode treats only defined non-zero exit codes as failures", () => {
   expect(isFailedExitCode(1)).toBe(true)
   expect(isFailedExitCode(0)).toBe(false)
   expect(isFailedExitCode(null)).toBe(false)
+})
+
+test("runProcess reports timeouts without treating null exits as failures", async () => {
+  const result = await runProcess(
+    ["node", "-e", "setTimeout(() => undefined, 1000)"],
+    { timeoutMs: 10 },
+  )
+
+  expect(result.timedOut).toBe(true)
+  expect(result.exitCode).toBe(null)
+  expect(isFailedExitCode(result.exitCode)).toBe(false)
+})
+
+test("runProcess keeps only the tail of stderr", async () => {
+  const result = await runProcess(
+    ["node", "-e", "process.stderr.write('abcde12345')"],
+    { timeoutMs: 1_000, maxStderrChars: 5 },
+  )
+
+  expect(result.stderr).toBe("12345")
+})
+
+test("runProcess rejects spawn errors", async () => {
+  await expect(
+    runProcess(["definitely-not-a-real-command-opencode-skill-creator"], {
+      timeoutMs: 1_000,
+    }),
+  ).rejects.toThrow()
 })

--- a/plugin/test/process.test.ts
+++ b/plugin/test/process.test.ts
@@ -1,0 +1,9 @@
+import { expect, test } from "bun:test"
+
+import { isFailedExitCode } from "../lib/process"
+
+test("isFailedExitCode treats only defined non-zero exit codes as failures", () => {
+  expect(isFailedExitCode(1)).toBe(true)
+  expect(isFailedExitCode(0)).toBe(false)
+  expect(isFailedExitCode(null)).toBe(false)
+})

--- a/plugin/test/process.test.ts
+++ b/plugin/test/process.test.ts
@@ -31,6 +31,21 @@ test("runProcess reports timeouts without treating null exits as failures", asyn
   expect(isFailedExitCode(result.exitCode)).toBe(false)
 })
 
+test("runProcess force kills processes that ignore timeout termination", async () => {
+  const startedAt = Date.now()
+  const result = await runProcess(
+    [
+      "node",
+      "-e",
+      "process.on('SIGTERM', () => {}); setTimeout(() => undefined, 2000)",
+    ],
+    { timeoutMs: 200, killGraceMs: 20 },
+  )
+
+  expect(result.timedOut).toBe(true)
+  expect(Date.now() - startedAt).toBeLessThan(1_000)
+})
+
 test("runProcess keeps only the tail of stderr", async () => {
   const result = await runProcess(
     ["node", "-e", "process.stderr.write('abcde12345')"],


### PR DESCRIPTION
## Summary
- replace remaining Bun.spawn calls in skill eval and description improvement with a shared Node child_process helper
- add a compiled runtime regression that rejects any Bun global API reference
- rebuild dist artifacts for the published plugin entrypoint

## Verification
- npm run build && node --test test/package.test.mjs
- npm test && npm run test:ts
- npm run prepack
- npm pack tarball check: package/dist versions 0.2.17 and no Bun runtime API references

## Release note
- v0.2.17 published successfully after npm trusted publisher setup, but tarball verification found these remaining Bun.spawn paths. This PR should let the release workflow auto-bump and publish the fully Node-compatible follow-up version.