### PR TITLE
fix(runtime): close stdin in runProcess so opencode run doesn't hang

### DIFF
--- a/plugin/dist/build-manifest.json
+++ b/plugin/dist/build-manifest.json
@@ -1,6 +1,6 @@
 {
   "entrypoint": "skill-creator.ts",
   "runtimeEntrypoint": "runtime-entry.ts",
-  "sourceHash": "2d062d73b563100ef01b0a1cc1693fb36c063d2ffcf2fa92828b3ada844c80c2",
-  "builtAt": "2026-05-25T06:32:15.069Z"
+  "sourceHash": "d97baab7740b78821d0f1a3550f1045b23d7c9ac87676859c23cdc63b5e29d6b",
+  "builtAt": "2026-06-16T10:20:15.936Z"
 }

--- a/plugin/dist/package.json
+++ b/plugin/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-skill-creator",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "OpenCode plugin for skill creation — custom tools for validation, evaluation, description optimization, benchmarking, and review serving.",
   "type": "module",
   "main": "./dist/skill-creator.js",

--- a/plugin/dist/skill-creator.js
+++ b/plugin/dist/skill-creator.js
@@ -12536,8 +12536,7 @@ function runProcess(command, opts) {
     const proc = spawn(file2, args, {
       cwd: opts.cwd,
       env: opts.env,
-      stdout: "pipe",
-      stderr: "pipe"
+      stdio: ["ignore", "pipe", "pipe"]
     });
     let stdout = "";
     let stderr = "";

--- a/plugin/lib/process.ts
+++ b/plugin/lib/process.ts
@@ -40,11 +40,13 @@ export function runProcess(command: string[], opts: RunProcessOptions): Promise<
 
     const maxStderrChars = opts.maxStderrChars ?? 64 * 1024
     const killGraceMs = opts.killGraceMs ?? 1_000
+    // stdin must be closed ("ignore"). The `opencode` binary blocks on an
+    // open-but-unwritten stdin pipe and produces no output — see the regression
+    // test in process.test.ts. `stdout`/`stderr` are not valid spawn keys.
     const proc = spawn(file, args, {
       cwd: opts.cwd,
       env: opts.env,
-      stdout: "pipe",
-      stderr: "pipe",
+      stdio: ["ignore", "pipe", "pipe"],
     })
     let stdout = ""
     let stderr = ""

--- a/plugin/test/process.test.ts
+++ b/plugin/test/process.test.ts
@@ -62,3 +62,24 @@ test("runProcess rejects spawn errors", async () => {
     }),
   ).rejects.toThrow()
 })
+
+test("runProcess does not hang when the child blocks on stdin", async () => {
+  // Regression for the silent stdio typo where `stdout: "pipe", stderr: "pipe"`
+  // was passed instead of `stdio: [...]`, leaving stdin as an unwritten pipe.
+  // The opencode binary (the real consumer) blocks on that stdin and produces
+  // zero output. We simulate that here with a child that explicitly reads stdin
+  // to EOF: with stdin closed it exits 0 immediately; with stdin piped open and
+  // no writer it would hang until the test timeout.
+  const result = await runProcess(
+    [
+      "node",
+      "-e",
+      "process.stdin.on('data', () => {}); process.stdin.on('end', () => { console.log('done'); process.exit(0) })",
+    ],
+    { timeoutMs: 3_000 },
+  )
+
+  expect(result.exitCode).toBe(0)
+  expect(result.timedOut).toBe(false)
+  expect(result.stdout.trim()).toBe("done")
+})


### PR DESCRIPTION
## Summary

`plugin/lib/process.ts` passed `stdout: "pipe"` and `stderr: "pipe"` to Node's `child_process.spawn`. **Neither of those keys exists on the spawn API** — they were silently ignored. Node fell back to the default `stdio: ["pipe", "pipe", "pipe"]`, leaving stdin as an open pipe with no writer.

The `opencode` binary (the only consumer of `runProcess`) blocks on that empty stdin pipe and produces no output. Every `skill_eval` / `skill_optimize_loop` query times out and gets recorded as `errors: 1, triggered: false`. From a shell (which closes/inherits stdin properly) `opencode run` works fine, so the bug is invisible during manual testing.

## Reproduction

Tested with a Node replica that uses the exact spawn options:

| Spawn options | Result |
|---|---|
| Default / `stdout:"pipe", stderr:"pipe"` (current code) | exit 0, **0 bytes** stdout in 240s (hangs until timeout) |
| `stdio: ["ignore", "pipe", "pipe"]` (this PR) | exit 0, **~28 KB** JSON stdout in ~70s, skill triggered correctly |

## Fix

One-line change: pass a real `stdio` array that closes stdin (`ignore`) and pipes stdout/stderr. `runProcess` never writes to the child's stdin, so `ignore` matches the original intent of the (broken) options.

## Tests

Added `process.test.ts > runProcess does not hang when the child blocks on stdin`. The test spawns a Node child that explicitly reads stdin to EOF: with the fix it exits 0 immediately; without the fix it would block until the test timeout.

All existing tests still pass (7/7).

## Related

Likely explains part of #8 ("Each of my skills receives 0% in the triggering evaluation"). The user there found that switching to the `build` agent improved things, but even with `build` the eval still hangs on stdin — the workaround only mitigated a separate "agent delegation hides tool events" issue, leaving this stdio bug latent.

## Risk

Minimal. `runProcess` is internal and never writes to the spawned child's stdin. The only behaviour change is that the child receives EOF on stdin immediately instead of waiting for input that never arrives.