### PR TITLE
fix(test): isolate run-loop mocks from run-eval suite

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "node ./scripts/build.mjs",
     "test": "node --test test/*.test.mjs",
-    "test:ts": "bun test test/*.test.ts",
+    "test:ts": "bun test --isolate test/*.test.ts",
     "prepack": "npm run build && npm test && npm run test:ts"
   },
   "dependencies": {

--- a/plugin/test/run-loop.test.ts
+++ b/plugin/test/run-loop.test.ts
@@ -1,8 +1,6 @@
-import { afterEach, expect, mock, test } from "bun:test"
+import { expect, mock, test } from "bun:test"
 
 import type { EvalItem, EvalOutput, EvalResultItem } from "../lib/run-eval"
-
-const calls: { evalResults: EvalOutput }[] = []
 
 const result = (
   query: string,
@@ -19,59 +17,56 @@ const result = (
   ...overrides,
 })
 
-mock.module("../lib/utils", () => ({
-  parseSkillMd: () => ({
-    name: "warning-skill",
-    description: "original description",
-    fullContent: "skill content",
-  }),
-}))
-
-mock.module("../lib/run-eval", () => ({
-  findProjectRoot: () => "/tmp/project",
-  buildEvalWarnings: (results: EvalResultItem[]) => {
-    const shouldTriggerResults = results.filter((r) => r.should_trigger)
-    if (shouldTriggerResults.length === 0) return []
-    return shouldTriggerResults.every((r) => r.triggers === 0 && r.errors === 0)
-      ? ["all-zero warning"]
-      : []
-  },
-  runEval: () => ({
-    skill_name: "warning-skill",
-    description: "original description",
-    results: [
-      result("train trigger"),
-      result("train negative", { should_trigger: false }),
-      result("test trigger"),
-    ],
-    warnings: [],
-    summary: {
-      passed: 1,
-      failed: 2,
-      total: 3,
-      run_errors: 0,
-      queries_with_errors: 0,
-    },
-  }),
-}))
-
-mock.module("../lib/improve-description", () => ({
-  improveDescription: (opts: { evalResults: EvalOutput }) => {
-    calls.push({ evalResults: opts.evalResults })
-    return "improved description"
-  },
-}))
-
-mock.module("../lib/report", () => ({
-  generateHtml: () => "<html></html>",
-}))
-
-afterEach(() => {
-  calls.length = 0
-})
-
 test("runLoop derives train warnings from train results and prints unique split warnings", async () => {
-  const { runLoop } = await import("../lib/run-loop")
+  const calls: { evalResults: EvalOutput }[] = []
+
+  mock.module("../lib/utils", () => ({
+    parseSkillMd: () => ({
+      name: "warning-skill",
+      description: "original description",
+      fullContent: "skill content",
+    }),
+  }))
+
+  mock.module("../lib/run-eval", () => ({
+    findProjectRoot: () => "/tmp/project",
+    buildEvalWarnings: (results: EvalResultItem[]) => {
+      const shouldTriggerResults = results.filter((r) => r.should_trigger)
+      if (shouldTriggerResults.length === 0) return []
+      return shouldTriggerResults.every((r) => r.triggers === 0 && r.errors === 0)
+        ? ["all-zero warning"]
+        : []
+    },
+    runEval: () => ({
+      skill_name: "warning-skill",
+      description: "original description",
+      results: [
+        result("train trigger"),
+        result("train negative", { should_trigger: false }),
+        result("test trigger"),
+      ],
+      warnings: [],
+      summary: {
+        passed: 1,
+        failed: 2,
+        total: 3,
+        run_errors: 0,
+        queries_with_errors: 0,
+      },
+    }),
+  }))
+
+  mock.module("../lib/improve-description", () => ({
+    improveDescription: (opts: { evalResults: EvalOutput }) => {
+      calls.push({ evalResults: opts.evalResults })
+      return "improved description"
+    },
+  }))
+
+  mock.module("../lib/report", () => ({
+    generateHtml: () => "<html></html>",
+  }))
+
   const evalSet: EvalItem[] = [
     { query: "train trigger", should_trigger: true },
     { query: "train negative", should_trigger: false },
@@ -84,6 +79,7 @@ test("runLoop derives train warnings from train results and prints unique split 
   }
 
   try {
+    const { runLoop } = await import("../lib/run-loop")
     await runLoop({
       evalSet,
       skillPath: "/tmp/skill/SKILL.md",
@@ -97,10 +93,11 @@ test("runLoop derives train warnings from train results and prints unique split 
       agent: undefined,
       verbose: true,
     })
+
+    expect(calls[0]?.evalResults.warnings).toEqual(["all-zero warning"])
+    expect(errors.filter((line) => line === "Warning: all-zero warning")).toHaveLength(2)
   } finally {
     console.error = originalError
+    mock.restore()
   }
-
-  expect(calls[0]?.evalResults.warnings).toEqual(["all-zero warning"])
-  expect(errors.filter((line) => line === "Warning: all-zero warning")).toHaveLength(2)
 })


### PR DESCRIPTION
## Summary
- Move `mock.module` calls in `run-loop.test.ts` into the test body and restore mocks in `finally`, so module stubs are not registered at file load time.
- Run Bun tests with `--isolate` in `test:ts` so each test file gets a fresh global scope and `mock.module` cannot leak across files.

Fixes the flaky publish failure in [#28](https://github.com/antongulin/opencode-skill-creator/actions/runs/27669206645) where `run-eval.test.ts` failed when `run-loop.test.ts` ran first:
```
SyntaxError: Export named 'buildOpenCodeRunCommand' not found in module '.../plugin/lib/run-eval.ts'
```

## Test plan
- [x] `bun test --randomize --isolate test/*.test.ts` (10 consecutive runs, 0 failures)
- [x] `bun test test/*.test.ts` (42 pass)
- [x] `npm test` in `plugin/`


Made with [Cursor](https://cursor.com)