### PR TITLE
fix(skill_eval): add conflict guard and normalize descriptionOverride

### DIFF
--- a/plugin/lib/run-eval.ts
+++ b/plugin/lib/run-eval.ts
@@ -225,6 +225,63 @@ async function runSingleQuery(
 }
 
 // ---------------------------------------------------------------------------
+// Conflict guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a skill with the same base name is already visible to
+ * `opencode` via installed skills or `skills.paths`. If so, throw because
+ * `skill_eval` creates a synthetic `<name>-skill-<id>` and only counts
+ * that temporary name as triggered — an installed skill with the base name
+ * can steal triggers and produce false negatives.
+ */
+export async function assertNoInstalledSkillConflict(
+  skillName: string,
+  projectRoot: string,
+): Promise<void> {
+  try {
+    const proc = Bun.spawn(["opencode", "debug", "skill"], {
+      cwd: projectRoot,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env },
+    })
+
+    const stdout = await new Response(proc.stdout).text()
+    await proc.exited
+
+    const skills = JSON.parse(stdout)
+    if (!Array.isArray(skills)) return
+
+    const conflicts = skills.filter(
+      (s: Record<string, unknown>) =>
+        s && typeof s === "object" && s.name === skillName,
+    )
+    if (conflicts.length === 0) return
+
+    const locations = conflicts
+      .map(
+        (s: Record<string, unknown>) =>
+          (typeof s.location === "string" ? s.location : "unknown location"),
+      )
+      .join(", ")
+
+    throw new Error(
+      `skill_eval conflict: skill "${skillName}" is already available to opencode at ${locations}. ` +
+        `Remove that installed skill or its skills.paths entry before running skill_eval. ` +
+        `The eval tool creates a synthetic skill named "${skillName}-skill-<id>" and only counts ` +
+        `that temporary skill as triggered; an installed skill with the base name can steal ` +
+        `triggers and produce false negatives.`,
+    )
+  } catch (e) {
+    // If `opencode debug skill` is unavailable or fails, skip the guard.
+    if (e instanceof Error && e.message.startsWith("skill_eval conflict:")) {
+      throw e
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Main entry
 // ---------------------------------------------------------------------------
 

--- a/plugin/skill-creator.ts
+++ b/plugin/skill-creator.ts
@@ -21,7 +21,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs"
 
 import { validateSkill } from "./lib/validate"
 import { parseSkillMd } from "./lib/utils"
-import { runEval, findProjectRoot } from "./lib/run-eval"
+import { runEval, findProjectRoot, assertNoInstalledSkillConflict } from "./lib/run-eval"
 import { improveDescription } from "./lib/improve-description"
 import { runLoop } from "./lib/run-loop"
 import { generateBenchmark, generateMarkdown } from "./lib/aggregate"
@@ -320,6 +320,15 @@ export async function maybeAutoRefreshPluginCache(
 }
 
 // ---------------------------------------------------------------------------
+// Normalize description override — treat empty string as omitted
+// ---------------------------------------------------------------------------
+
+function normalizeDescriptionOverride(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined
+  return value.trim().length === 0 ? undefined : value
+}
+
+// ---------------------------------------------------------------------------
 // Track running review servers so they can be stopped
 // ---------------------------------------------------------------------------
 
@@ -506,11 +515,12 @@ export const SkillCreatorPlugin: Plugin = async (ctx) => {
 
           const meta = parseSkillMd(args.skillPath)
           const projectRoot = findProjectRoot()
+          await assertNoInstalledSkillConflict(meta.name, projectRoot)
 
           const result = await runEval({
             evalSet,
             skillName: meta.name,
-            description: args.descriptionOverride ?? meta.description,
+            description: normalizeDescriptionOverride(args.descriptionOverride) ?? meta.description,
             numWorkers: args.numWorkers ?? 10,
             timeout: args.timeout ?? 30,
             projectRoot,
@@ -641,10 +651,14 @@ export const SkillCreatorPlugin: Plugin = async (ctx) => {
             readFileSync(args.evalSetPath, "utf-8"),
           )
 
+          const meta = parseSkillMd(args.skillPath)
+          const projectRoot = findProjectRoot()
+          await assertNoInstalledSkillConflict(meta.name, projectRoot)
+
           const result = await runLoop({
             evalSet,
             skillPath: args.skillPath,
-            descriptionOverride: args.descriptionOverride ?? null,
+            descriptionOverride: normalizeDescriptionOverride(args.descriptionOverride) ?? null,
             numWorkers: args.numWorkers ?? 10,
             timeout: args.timeout ?? 30,
             maxIterations: args.maxIterations ?? 5,

--- a/plugin/skill/SKILL.md
+++ b/plugin/skill/SKILL.md
@@ -348,6 +348,19 @@ This is optional, requires the Task tool (using `general` subagent type), and mo
 
 ---
 
+## Trigger Eval Preflight
+
+Before running `skill_eval` or `skill_optimize_loop`, ensure no installed skill conflicts with the skill being tested. `skill_eval` creates a synthetic skill named `<skill-name>-skill-<id>` and only counts invocations of that exact temporary name as triggered. If a real skill with the base name is already visible to OpenCode (via `skills.paths`, installed in `~/.config/opencode/skills/`, or project-level `.opencode/skills/`), the model may load the real skill instead of the synthetic one, producing false negatives.
+
+**Before running eval, check:**
+1. Run `opencode debug skill` — if the skill name appears in the output, it's installed and will conflict.
+2. Remove the conflicting skill or its `skills.paths` entry.
+3. Re-run eval.
+
+The `skill_eval` and `skill_optimize_loop` tools now check for this automatically and throw a clear error if a conflict is detected.
+
+---
+
 ## Description Optimization
 
 The description field in SKILL.md frontmatter is the primary mechanism that determines whether OpenCode invokes a skill. After creating or improving a skill, offer to optimize the description for better triggering accuracy.


### PR DESCRIPTION
## Problem

`skill_eval` creates a synthetic skill named `<skill-name>-skill-<id>` and only counts invocations of that exact temporary name as triggered. If a real skill with the base name is already visible to OpenCode (via `skills.paths`, installed in `~/.config/opencode/skills/`, or project-level `.opencode/skills/`), the model may load the real skill instead of the synthetic one, producing false negatives — the eval reports `trigger_rate: 0` even though the skill description is good.

Additionally, passing an empty string as `descriptionOverride` would override the SKILL.md description with `""`, which is almost never intentional.

## Changes

1. **`plugin/lib/run-eval.ts`**: Add `assertNoInstalledSkillConflict()` that runs `opencode debug skill` and throws a clear error if the skill name appears in the installed skills list.

2. **`plugin/skill-creator.ts`**:
   - Add `normalizeDescriptionOverride()` — treats empty/whitespace-only strings as `undefined` so the SKILL.md description is used.
   - Call `assertNoInstalledSkillConflict()` before both `skill_eval` and `skill_optimize_loop` execution.

3. **`plugin/skill/SKILL.md`**: Add a "Trigger Eval Preflight" section documenting the issue and the automatic guard.

## Testing

- Build passes (`npm run build`)
- Verified locally that removing the installed skill from `skills.paths` resolves the false-negative issue