### PR TITLE
fix(skill_eval): add trigger-only mode

### DIFF
--- a/plugin/dist/build-manifest.json
+++ b/plugin/dist/build-manifest.json
@@ -1,6 +1,6 @@
 {
   "entrypoint": "skill-creator.ts",
   "runtimeEntrypoint": "runtime-entry.ts",
-  "sourceHash": "d97baab7740b78821d0f1a3550f1045b23d7c9ac87676859c23cdc63b5e29d6b",
-  "builtAt": "2026-06-16T10:20:15.936Z"
+  "sourceHash": "6e4c1da97ef75f263cacd5f8e706bd849c99792b84a7a505148fa234de660aaf",
+  "builtAt": "2026-06-23T08:01:15.963Z"
 }

--- a/plugin/dist/package.json
+++ b/plugin/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-skill-creator",
-  "version": "0.2.18",
+  "version": "0.2.20",
   "description": "OpenCode plugin for skill creation — custom tools for validation, evaluation, description optimization, benchmarking, and review serving.",
   "type": "module",
   "main": "./dist/skill-creator.js",
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "node ./scripts/build.mjs",
     "test": "node --test test/*.test.mjs",
-    "test:ts": "bun test test/*.test.ts",
+    "test:ts": "bun test --isolate test/*.test.ts",
     "prepack": "npm run build && npm test && npm run test:ts"
   },
   "dependencies": {

--- a/plugin/dist/skill-creator.js
+++ b/plugin/dist/skill-creator.js
@@ -12542,7 +12542,19 @@ function runProcess(command, opts) {
     let stderr = "";
     let timedOut = false;
     let settled = false;
+    let stopRequested = false;
     let killTimeoutId;
+    const requestStop = () => {
+      if (settled || stopRequested)
+        return;
+      stopRequested = true;
+      proc.kill();
+      killTimeoutId = setTimeout(() => {
+        if (!settled) {
+          proc.kill("SIGKILL");
+        }
+      }, killGraceMs);
+    };
     const timeoutId = setTimeout(() => {
       timedOut = true;
       proc.kill();
@@ -12555,7 +12567,9 @@ function runProcess(command, opts) {
     proc.stdout.setEncoding("utf-8");
     proc.stdout.on("data", (chunk) => {
       stdout += chunk;
-      opts.onStdoutChunk?.(chunk);
+      const shouldStop = opts.onStdoutChunk?.(chunk);
+      if (shouldStop)
+        requestStop();
     });
     proc.stderr.setEncoding("utf-8");
     proc.stderr.on("data", (chunk) => {
@@ -12624,7 +12638,7 @@ function findProjectRoot(cwd) {
   }
   return cwd ?? process.cwd();
 }
-async function runSingleQuery(query, skillName, skillDescription, timeout, projectRoot, agent, model) {
+async function runSingleQuery(query, skillName, skillDescription, timeout, projectRoot, agent, triggerOnly, model) {
   if (!SKILL_NAME_RE.test(skillName)) {
     throw new Error(`Invalid skill name "${skillName}". Expected kebab-case (lowercase letters, numbers, and hyphens only).`);
   }
@@ -12699,9 +12713,13 @@ async function runSingleQuery(query, skillName, skillDescription, timeout, proje
       onStdoutChunk(chunk) {
         buffer += chunk;
         flushBuffer();
+        return triggerOnly && triggered;
       }
     });
     flushBuffer(true);
+    if (triggered) {
+      return true;
+    }
     if (isFailedProcess(result)) {
       const cleanedStderr = result.stderr.trim();
       throw new Error(cleanedStderr ? `opencode run exited ${result.exitCode}: ${cleanedStderr}` : `opencode run exited ${result.exitCode}`);
@@ -12723,6 +12741,7 @@ async function runEval(opts) {
     projectRoot,
     runsPerQuery = 3,
     triggerThreshold = 0.5,
+    triggerOnly = true,
     model,
     agent = "build"
   } = opts;
@@ -12740,7 +12759,7 @@ async function runEval(opts) {
       if (!job)
         break;
       try {
-        const triggered = await runSingleQuery(job.item.query, skillName, description, timeout, projectRoot, agent, model);
+        const triggered = await runSingleQuery(job.item.query, skillName, description, timeout, projectRoot, agent, triggerOnly, model);
         jobResults.push({
           query: job.item.query,
           triggered,
@@ -13383,6 +13402,7 @@ async function runLoop(opts) {
     maxIterations,
     runsPerQuery,
     triggerThreshold,
+    triggerOnly,
     holdout,
     model,
     agent,
@@ -13425,6 +13445,7 @@ ${"=".repeat(60)}`);
       projectRoot,
       runsPerQuery,
       triggerThreshold,
+      triggerOnly,
       model,
       agent
     });
@@ -14964,6 +14985,7 @@ var SkillCreatorPlugin = async (ctx) => {
           timeout: tool.schema.number().optional().describe("Timeout per query in seconds (default: 30)"),
           runsPerQuery: tool.schema.number().optional().describe("Number of runs per query for reliability (default: 3)"),
           triggerThreshold: tool.schema.number().optional().describe("Trigger rate threshold to count as triggered (default: 0.5)"),
+          triggerOnly: tool.schema.boolean().optional().describe("Stop each eval run as soon as the synthetic skill is triggered and ignore later workflow failures (default: true)"),
           model: tool.schema.string().optional().describe("Model ID in provider/model format"),
           agent: tool.schema.string().optional().describe("OpenCode agent for trigger eval runs (default: build)")
         },
@@ -14985,6 +15007,7 @@ var SkillCreatorPlugin = async (ctx) => {
             projectRoot,
             runsPerQuery: args.runsPerQuery ?? 3,
             triggerThreshold: args.triggerThreshold ?? 0.5,
+            triggerOnly: args.triggerOnly ?? true,
             model: args.model,
             agent: args.agent ?? "build"
           });
@@ -15030,6 +15053,7 @@ var SkillCreatorPlugin = async (ctx) => {
           timeout: tool.schema.number().optional().describe("Timeout per query in seconds (default: 30)"),
           runsPerQuery: tool.schema.number().optional().describe("Runs per query (default: 3)"),
           triggerThreshold: tool.schema.number().optional().describe("Trigger rate threshold (default: 0.5)"),
+          triggerOnly: tool.schema.boolean().optional().describe("Stop each eval run as soon as the synthetic skill is triggered and ignore later workflow failures (default: true)"),
           holdout: tool.schema.number().optional().describe("Test set holdout fraction (default: 0.4)"),
           model: tool.schema.string().optional().describe("Model ID in provider/model format"),
           agent: tool.schema.string().optional().describe("OpenCode agent for trigger eval runs (default: build)"),
@@ -15048,6 +15072,7 @@ var SkillCreatorPlugin = async (ctx) => {
             maxIterations: args.maxIterations ?? 5,
             runsPerQuery: args.runsPerQuery ?? 3,
             triggerThreshold: args.triggerThreshold ?? 0.5,
+            triggerOnly: args.triggerOnly ?? true,
             holdout: args.holdout ?? 0.4,
             model: args.model,
             agent: args.agent ?? "build",

--- a/plugin/lib/process.ts
+++ b/plugin/lib/process.ts
@@ -6,7 +6,7 @@ interface RunProcessOptions {
   timeoutMs: number
   killGraceMs?: number
   maxStderrChars?: number
-  onStdoutChunk?: (chunk: string) => void
+  onStdoutChunk?: (chunk: string) => boolean | void
 }
 
 export interface RunProcessResult {
@@ -52,7 +52,19 @@ export function runProcess(command: string[], opts: RunProcessOptions): Promise<
     let stderr = ""
     let timedOut = false
     let settled = false
+    let stopRequested = false
     let killTimeoutId: ReturnType<typeof setTimeout> | undefined
+
+    const requestStop = () => {
+      if (settled || stopRequested) return
+      stopRequested = true
+      proc.kill()
+      killTimeoutId = setTimeout(() => {
+        if (!settled) {
+          proc.kill("SIGKILL")
+        }
+      }, killGraceMs)
+    }
 
     const timeoutId = setTimeout(() => {
       timedOut = true
@@ -67,7 +79,8 @@ export function runProcess(command: string[], opts: RunProcessOptions): Promise<
     proc.stdout.setEncoding("utf-8")
     proc.stdout.on("data", (chunk: string) => {
       stdout += chunk
-      opts.onStdoutChunk?.(chunk)
+      const shouldStop = opts.onStdoutChunk?.(chunk)
+      if (shouldStop) requestStop()
     })
 
     proc.stderr.setEncoding("utf-8")

--- a/plugin/lib/run-eval.ts
+++ b/plugin/lib/run-eval.ts
@@ -115,6 +115,7 @@ async function runSingleQuery(
   timeout: number,
   projectRoot: string,
   agent: string,
+  triggerOnly: boolean,
   model?: string,
 ): Promise<boolean> {
   if (!SKILL_NAME_RE.test(skillName)) {
@@ -201,10 +202,15 @@ async function runSingleQuery(
       onStdoutChunk(chunk) {
         buffer += chunk
         flushBuffer()
+        return triggerOnly && triggered
       },
     })
 
     flushBuffer(true)
+
+    if (triggered) {
+      return true
+    }
 
     if (isFailedProcess(result)) {
       const cleanedStderr = result.stderr.trim()
@@ -237,6 +243,7 @@ export interface RunEvalOptions {
   projectRoot: string
   runsPerQuery?: number
   triggerThreshold?: number
+  triggerOnly?: boolean
   model?: string
   agent?: string
 }
@@ -257,6 +264,7 @@ export async function runEval(opts: RunEvalOptions): Promise<EvalOutput> {
     projectRoot,
     runsPerQuery = 3,
     triggerThreshold = 0.5,
+    triggerOnly = true,
     model,
     agent = "build",
   } = opts
@@ -291,6 +299,7 @@ export async function runEval(opts: RunEvalOptions): Promise<EvalOutput> {
           timeout,
           projectRoot,
           agent,
+          triggerOnly,
           model,
         )
         jobResults.push({

--- a/plugin/lib/run-loop.ts
+++ b/plugin/lib/run-loop.ts
@@ -88,6 +88,7 @@ export interface RunLoopOptions {
   maxIterations: number
   runsPerQuery: number
   triggerThreshold: number
+  triggerOnly: boolean
   holdout: number
   model: string | undefined
   agent: string | undefined
@@ -142,6 +143,7 @@ export async function runLoop(opts: RunLoopOptions): Promise<RunLoopOutput> {
     maxIterations,
     runsPerQuery,
     triggerThreshold,
+    triggerOnly,
     holdout,
     model,
     agent,
@@ -193,6 +195,7 @@ export async function runLoop(opts: RunLoopOptions): Promise<RunLoopOutput> {
       projectRoot,
       runsPerQuery,
       triggerThreshold,
+      triggerOnly,
       model,
       agent,
     })

--- a/plugin/skill-creator.ts
+++ b/plugin/skill-creator.ts
@@ -484,6 +484,10 @@ export const SkillCreatorPlugin: Plugin = async (ctx) => {
             .number()
             .optional()
             .describe("Trigger rate threshold to count as triggered (default: 0.5)"),
+          triggerOnly: tool.schema
+            .boolean()
+            .optional()
+            .describe("Stop each eval run as soon as the synthetic skill is triggered and ignore later workflow failures (default: true)"),
           model: tool.schema
             .string()
             .optional()
@@ -516,6 +520,7 @@ export const SkillCreatorPlugin: Plugin = async (ctx) => {
             projectRoot,
             runsPerQuery: args.runsPerQuery ?? 3,
             triggerThreshold: args.triggerThreshold ?? 0.5,
+            triggerOnly: args.triggerOnly ?? true,
             model: args.model,
             agent: args.agent ?? "build",
           })
@@ -614,6 +619,10 @@ export const SkillCreatorPlugin: Plugin = async (ctx) => {
             .number()
             .optional()
             .describe("Trigger rate threshold (default: 0.5)"),
+          triggerOnly: tool.schema
+            .boolean()
+            .optional()
+            .describe("Stop each eval run as soon as the synthetic skill is triggered and ignore later workflow failures (default: true)"),
           holdout: tool.schema
             .number()
             .optional()
@@ -650,6 +659,7 @@ export const SkillCreatorPlugin: Plugin = async (ctx) => {
             maxIterations: args.maxIterations ?? 5,
             runsPerQuery: args.runsPerQuery ?? 3,
             triggerThreshold: args.triggerThreshold ?? 0.5,
+            triggerOnly: args.triggerOnly ?? true,
             holdout: args.holdout ?? 0.4,
             model: args.model,
             agent: args.agent ?? "build",

--- a/plugin/test/process.test.ts
+++ b/plugin/test/process.test.ts
@@ -83,3 +83,24 @@ test("runProcess does not hang when the child blocks on stdin", async () => {
   expect(result.timedOut).toBe(false)
   expect(result.stdout.trim()).toBe("done")
 })
+
+test("runProcess can stop early from stdout parsing without timing out", async () => {
+  const startedAt = Date.now()
+  const result = await runProcess(
+    [
+      "node",
+      "-e",
+      "process.stdout.write('triggered\\n'); setTimeout(() => process.stdout.write('late\\n'), 1000)",
+    ],
+    {
+      timeoutMs: 3_000,
+      onStdoutChunk(chunk) {
+        return chunk.includes("triggered")
+      },
+    },
+  )
+
+  expect(result.timedOut).toBe(false)
+  expect(result.stdout).toContain("triggered")
+  expect(Date.now() - startedAt).toBeLessThan(1_000)
+})

--- a/plugin/test/run-loop.test.ts
+++ b/plugin/test/run-loop.test.ts
@@ -88,6 +88,7 @@ test("runLoop derives train warnings from train results and prints unique split 
       maxIterations: 2,
       runsPerQuery: 3,
       triggerThreshold: 0.5,
+      triggerOnly: true,
       holdout: 1 / 3,
       model: undefined,
       agent: undefined,


### PR DESCRIPTION
## Problem

`skill_eval` runs every query through `opencode run` even after the synthetic skill has already triggered. This wastes time on downstream workflow output that is irrelevant to trigger detection, and can cause false negatives when the model later hits rate limits, timeouts, or unrelated errors.

## Changes

1. **`plugin/lib/process.ts`**: Allow `onStdoutChunk` callback to return `boolean`. When `true`, kill the child process early (with graceful + SIGKILL fallback).

2. **`plugin/lib/run-eval.ts`**:
   - Add `triggerOnly` option (default `true`) to `RunEvalOptions` and `runSingleQuery`.
   - When `triggerOnly=true` and the synthetic skill name appears in stdout, immediately return `true` without waiting for the full process to finish.

3. **`plugin/lib/run-loop.ts`**: Thread `triggerOnly` through `RunLoopOptions` into `runEval`.

4. **`plugin/skill-creator.ts`**: Expose `triggerOnly` boolean schema arg on both `skill_eval` and `skill_optimize_loop` tools.

5. **Tests**: Add early-stop test in `process.test.ts`; add `triggerOnly: true` to `run-loop.test.ts` fixture.

## Testing

- `npm run build` passes
- `npm run test:ts`: 44 pass, 0 fail
- Live eval on `video-summary` with GPT-5.4: 3/3 passed, triggerOnly stopped runs immediately after trigger